### PR TITLE
fix: update package name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ade-typescript",
+  "name": "landingai-ade",
   "version": "0.3.1",
   "description": "The official TypeScript library for the Ade API",
   "author": "Ade <>",


### PR DESCRIPTION
Package name is read from package.json when doing an npm publish. For some reason changing the package name in our config didn't update in package.json so I'm doing it manually then the stainless release should track the correct npm package.

```bash
# Get package name and version from package.json
PACKAGE_NAME="$(jq -r -e '.name' ./package.json)"
```