### PR TITLE
feat: add saveTo to classify and section

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -322,10 +322,22 @@ export class LandingAIADE {
    * `https://api.va.eu-west-1.landing.ai/v1/ade/classify`.
    */
   classify(
-    body: TopLevelAPI.ClassifyParams,
+    body: TopLevelAPI.ClassifyParams & { saveTo?: string },
     options?: RequestOptions,
   ): APIPromise<TopLevelAPI.ClassifyResponse> {
-    return this.post('/v1/ade/classify', multipartFormRequestOptions({ body, ...options }, this));
+    const { saveTo, ...apiBody } = body;
+    const promise = this.post<TopLevelAPI.ClassifyResponse>(
+      '/v1/ade/classify',
+      multipartFormRequestOptions({ body: apiBody, ...options }, this),
+    );
+    if (saveTo) {
+      const filename = _getInputFilename(apiBody.document, apiBody.document_url);
+      return promise._thenUnwrap((data) => {
+        _saveResponse(saveTo, filename, 'classify', data);
+        return data;
+      });
+    }
+    return promise;
   }
 
   /**
@@ -417,10 +429,22 @@ export class LandingAIADE {
    * `https://api.va.eu-west-1.landing.ai/v1/ade/section`.
    */
   section(
-    body: TopLevelAPI.SectionParams,
+    body: TopLevelAPI.SectionParams & { saveTo?: string },
     options?: RequestOptions,
   ): APIPromise<TopLevelAPI.SectionResponse> {
-    return this.post('/v1/ade/section', multipartFormRequestOptions({ body, ...options }, this));
+    const { saveTo, ...apiBody } = body;
+    const promise = this.post<TopLevelAPI.SectionResponse>(
+      '/v1/ade/section',
+      multipartFormRequestOptions({ body: apiBody, ...options }, this),
+    );
+    if (saveTo) {
+      const filename = _getInputFilename(apiBody.markdown, apiBody.markdown_url);
+      return promise._thenUnwrap((data) => {
+        _saveResponse(saveTo, filename, 'section', data);
+        return data;
+      });
+    }
+    return promise;
   }
 
   /**

--- a/tests/save-to.test.ts
+++ b/tests/save-to.test.ts
@@ -115,6 +115,12 @@ describe('_saveResponse', () => {
 
     _saveResponse(testDir, 'myinput', 'split', result);
     expect(fs.existsSync(path.join(testDir, 'myinput_split_output.json'))).toBe(true);
+
+    _saveResponse(testDir, 'myinput', 'classify', result);
+    expect(fs.existsSync(path.join(testDir, 'myinput_classify_output.json'))).toBe(true);
+
+    _saveResponse(testDir, 'myinput', 'section', result);
+    expect(fs.existsSync(path.join(testDir, 'myinput_section_output.json'))).toBe(true);
   });
 
   it('creates nested directories', () => {
@@ -128,7 +134,7 @@ describe('_saveResponse', () => {
 
   it('skips redundant "output" prefix when filename is "output"', () => {
     const result = {};
-    for (const method of ['parse', 'extract', 'split']) {
+    for (const method of ['parse', 'extract', 'split', 'classify', 'section']) {
       _saveResponse(testDir, 'output', method, result);
       expect(fs.existsSync(path.join(testDir, `${method}_output.json`))).toBe(true);
       expect(fs.existsSync(path.join(testDir, `output_${method}_output.json`))).toBe(false);


### PR DESCRIPTION
## Summary

Wires `saveTo` into `classify` and `section`, mirroring the smart saveTo behavior shipped for `parse`, `extract`, and `split` in PR #62.

- `client.classify({..., saveTo: DIR})` → `{input_stem}_classify_output.json`
- `client.classify({..., saveTo: 'path/to/file.json'})` → exact path, parent dirs created
- `client.section({..., saveTo: DIR})` with parsed-markdown string → `section_output.json` (no redundant prefix)
- `client.section({..., saveTo: DIR})` with markdown ReadStream → `{stem}_section_output.json`
- Reuses existing `_getInputFilename` and `_saveResponse` helpers — no new utility code

Both methods now accept the same `body & { saveTo?: string }` intersection pattern used by `parse`, `extract`, and `split`.

## Test plan

- [x] Existing parse/extract/split saveTo unit tests still pass
- [x] `tests/save-to.test.ts` filename-format and redundant-prefix loops extended to include `classify` and `section`
- [x] All 18 tests in `tests/save-to.test.ts` pass locally
- [x] `tsc --noEmit` clean
- [x] Live integration (staging via sdk-testing): 5/5 — classify + section, both directory mode and full `.json` path mode