### PR TITLE
chore: remove Stainless-generated file headers

### DIFF
--- a/examples/.keep
+++ b/examples/.keep
@@ -1,4 +1,1 @@
-File generated from our OpenAPI spec by Stainless.
-
-This directory can be used to store example files demonstrating usage of this SDK.
-It is ignored by Stainless code generation and its content (other than this keep file) won't be touched.
+This directory can be used to store custom files to expand the SDK.

--- a/packages/mcp-server/src/auth.ts
+++ b/packages/mcp-server/src/auth.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import { IncomingMessage } from 'node:http';
 import { ClientOptions } from 'landingai-ade';
 import { McpOptions } from './options';

--- a/packages/mcp-server/src/code-tool-paths.cts
+++ b/packages/mcp-server/src/code-tool-paths.cts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 export function getWorkerPath(): string {
   return require.resolve('./code-tool-worker.mjs');
 }

--- a/packages/mcp-server/src/code-tool-types.ts
+++ b/packages/mcp-server/src/code-tool-types.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import { ClientOptions } from 'landingai-ade';
 
 export type WorkerInput = {

--- a/packages/mcp-server/src/code-tool-worker.ts
+++ b/packages/mcp-server/src/code-tool-worker.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import path from 'node:path';
 import util from 'node:util';
 import Fuse from 'fuse.js';

--- a/packages/mcp-server/src/code-tool.ts
+++ b/packages/mcp-server/src/code-tool.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import {
   ContentBlock,
   McpRequestContext,

--- a/packages/mcp-server/src/docs-search-tool.ts
+++ b/packages/mcp-server/src/docs-search-tool.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { Metadata, McpRequestContext, asTextContentResult } from './types';
 import { getLogger } from './logger';

--- a/packages/mcp-server/src/http.ts
+++ b/packages/mcp-server/src/http.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { ClientOptions } from 'landingai-ade';

--- a/packages/mcp-server/src/instructions.ts
+++ b/packages/mcp-server/src/instructions.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import fs from 'fs/promises';
 import { getLogger } from './logger';
 import { readEnv } from './util';

--- a/packages/mcp-server/src/local-docs-search.ts
+++ b/packages/mcp-server/src/local-docs-search.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import MiniSearch from 'minisearch';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';

--- a/packages/mcp-server/src/logger.ts
+++ b/packages/mcp-server/src/logger.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import { pino, type Level, type Logger } from 'pino';
 import pretty from 'pino-pretty';
 

--- a/packages/mcp-server/src/methods.ts
+++ b/packages/mcp-server/src/methods.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import { McpOptions } from './options';
 
 export type SdkMethod = {

--- a/packages/mcp-server/src/options.ts
+++ b/packages/mcp-server/src/options.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import qs from 'qs';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import LandingAIADE from 'landingai-ade';
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
 

--- a/packages/mcp-server/src/util.ts
+++ b/packages/mcp-server/src/util.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 export const readEnv = (env: string): string | undefined => {
   if (typeof (globalThis as any).process !== 'undefined') {
     return (globalThis as any).process.env?.[env]?.trim() || undefined;

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import * as fs from 'fs';
 import * as path from 'path';
 import type { RequestInit, RequestInfo, BodyInit } from './internal/builtin-types';

--- a/src/core/api-promise.ts
+++ b/src/core/api-promise.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import { type LandingAIADE } from '../client';
 
 import { type PromiseOrValue } from '../internal/types';

--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import { castToError } from '../internal/errors';
 
 export class LandingAIADEError extends Error {}

--- a/src/core/resource.ts
+++ b/src/core/resource.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import type { LandingAIADE } from '../client';
 
 export abstract class APIResource {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 export { LandingAIADE as default } from './client';
 
 export { type Uploadable, toFile } from './core/uploads';

--- a/src/internal/builtin-types.ts
+++ b/src/internal/builtin-types.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 export type Fetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
 /**

--- a/src/internal/detect-platform.ts
+++ b/src/internal/detect-platform.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import { VERSION } from '../version';
 
 export const isRunningInBrowser = () => {

--- a/src/internal/errors.ts
+++ b/src/internal/errors.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 export function isAbortError(err: unknown) {
   return (
     typeof err === 'object' &&

--- a/src/internal/headers.ts
+++ b/src/internal/headers.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import { isReadonlyArray } from './utils/values';
 
 type HeaderValue = string | undefined | null;

--- a/src/internal/parse.ts
+++ b/src/internal/parse.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import type { FinalRequestOptions } from './request-options';
 import { type LandingAIADE } from '../client';
 import { formatRequestDetails, loggerFor } from './utils/log';

--- a/src/internal/request-options.ts
+++ b/src/internal/request-options.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import { NullableHeaders } from './headers';
 
 import type { BodyInit } from './builtin-types';

--- a/src/internal/shim-types.ts
+++ b/src/internal/shim-types.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 /**
  * Shims for types that we can't always rely on being available globally.
  *

--- a/src/internal/shims.ts
+++ b/src/internal/shims.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 /**
  * This module provides internal shims and utility functions for environments where certain Node.js or global types may not be available.
  *

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 export type PromiseOrValue<T> = T | Promise<T>;
 export type HTTPMethod = 'get' | 'post' | 'put' | 'patch' | 'delete';
 

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 export * from './utils/values';
 export * from './utils/base64';
 export * from './utils/env';

--- a/src/internal/utils/base64.ts
+++ b/src/internal/utils/base64.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import { LandingAIADEError } from '../../core/error';
 import { encodeUTF8 } from './bytes';
 

--- a/src/internal/utils/env.ts
+++ b/src/internal/utils/env.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 /**
  * Read an environment variable.
  *

--- a/src/internal/utils/log.ts
+++ b/src/internal/utils/log.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import { hasOwn } from './values';
 import { type LandingAIADE } from '../../client';
 import { RequestOptions } from '../request-options';

--- a/src/internal/utils/query.ts
+++ b/src/internal/utils/query.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import { LandingAIADEError } from '../../core/error';
 
 /**

--- a/src/internal/utils/sleep.ts
+++ b/src/internal/utils/sleep.ts
@@ -1,3 +1,1 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 export const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));

--- a/src/internal/utils/uuid.ts
+++ b/src/internal/utils/uuid.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 /**
  * https://stackoverflow.com/a/2117523
  */

--- a/src/internal/utils/values.ts
+++ b/src/internal/utils/values.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import { LandingAIADEError } from '../../core/error';
 
 // https://url.spec.whatwg.org/#url-scheme-string

--- a/src/lib/.keep
+++ b/src/lib/.keep
@@ -1,4 +1,1 @@
-File generated from our OpenAPI spec by Stainless.
-
 This directory can be used to store custom files to expand the SDK.
-It is ignored by Stainless code generation and its content (other than this keep file) won't be touched.

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 export * from './shared';
 export {
   ParseJobs,

--- a/src/resources/parse-jobs.ts
+++ b/src/resources/parse-jobs.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import { APIResource } from '../core/resource';
 import * as Shared from './shared';
 import { APIPromise } from '../core/api-promise';

--- a/src/resources/shared.ts
+++ b/src/resources/shared.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 export interface ParseGroundingBox {
   bottom: number;
 

--- a/src/resources/top-level.ts
+++ b/src/resources/top-level.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import * as Shared from './shared';
 import { type Uploadable } from '../core/uploads';
 

--- a/tests/api-resources/parse-jobs.test.ts
+++ b/tests/api-resources/parse-jobs.test.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import LandingAIADE from 'landingai-ade';
 
 const client = new LandingAIADE({

--- a/tests/api-resources/top-level.test.ts
+++ b/tests/api-resources/top-level.test.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import LandingAIADE, { toFile } from 'landingai-ade';
 
 const client = new LandingAIADE({

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import { APIPromise } from 'landingai-ade/core/api-promise';
 
 import util from 'node:util';

--- a/tests/stringifyQuery.test.ts
+++ b/tests/stringifyQuery.test.ts
@@ -1,5 +1,3 @@
-// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
 import { stringifyQuery } from 'landingai-ade/internal/utils/query';
 
 describe(stringifyQuery, () => {


### PR DESCRIPTION
Mechanical companion to landing-ai/ade-python's sweep (promised in the ade-python#100 review): removes the first-line `// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.` from all 45 source files (`.ts`/`.cts`), and rewrites the two `.keep` placeholders whose body text also described Stainless codegen behavior.

**Verified locally on the swept tree**: `./scripts/lint`, `./scripts/build`, and `./scripts/test` all green (235 passed / 13 skipped).

Stacked on #70 (`chore/stainless-exit`) — GitHub will retarget to `main` automatically when that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)