### PR TITLE
fix: drop stale v2 extract params (markdown_ref, idempotency_key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ console.log(response.markdown);
 
 #### V2 Extract
 
-Extract structured data from Markdown using a JSON schema. Provide exactly one of `markdown`, `markdown_ref` (from `client.v2.files.upload`), or `markdown_url`.
+Extract structured data from Markdown using a JSON schema. Provide exactly one of `markdown` or `markdown_url`.
 
 ```ts
 const response = await client.v2.extract({
@@ -229,16 +229,6 @@ const done = await client.v2.parseJobs.wait(job.job_id, { timeout: 600000, raise
 console.log(done.status, done.result);
 
 // client.v2.extractJobs.{create,get,list,wait} mirror the same shape for extract jobs.
-```
-
-#### File staging
-
-`client.v2.files.upload` stages bytes on the ADE data plane and returns a `file_ref` you can pass as `markdown_ref` to extract:
-
-<!-- prettier-ignore -->
-```ts
-const fileRef = await client.v2.files.upload({ file: fs.createReadStream('doc.md') });
-const result = await client.v2.extract({ schema: { type: 'object' }, markdown_ref: fileRef });
 ```
 
 `client.v2.parse` and `client.v2.extract` also accept `saveTo`, with the same auto-naming behavior as the V1 methods above.

--- a/src/resources/v2/extract.ts
+++ b/src/resources/v2/extract.ts
@@ -24,9 +24,6 @@ export interface V2ExtractParams {
   /** Markdown content to extract data from. */
   markdown?: string | null;
 
-  /** A reference (e.g. from a prior parse or `files.upload`) to markdown content. */
-  markdown_ref?: string | null;
-
   /** URL to the markdown file to extract data from. */
   markdown_url?: string | null;
 
@@ -38,9 +35,6 @@ export interface V2ExtractParams {
    * prune unsupported fields and continue. Sent as `options.strict`.
    */
   strict?: boolean | null;
-
-  /** An idempotency key for the request. */
-  idempotency_key?: string | null;
 }
 
 export interface V2ExtractJobCreateParams extends V2ExtractParams {
@@ -55,10 +49,8 @@ export function buildExtractBody(params: V2ExtractJobCreateParams): Record<strin
   const body: Record<string, unknown> = { schema: coerceSchema(params.schema) };
   const entries: Array<[string, unknown]> = [
     ['markdown', params.markdown],
-    ['markdown_ref', params.markdown_ref],
     ['markdown_url', params.markdown_url],
     ['model', params.model],
-    ['idempotency_key', params.idempotency_key],
     ['service_tier', params.service_tier],
   ];
   for (const [key, value] of entries) {

--- a/src/resources/v2/files.ts
+++ b/src/resources/v2/files.ts
@@ -12,9 +12,8 @@ export interface FileUploadParams {
 
 export class Files extends V2Resource {
   /**
-   * Stage a file's bytes on the ADE data plane and return a `file_ref` string,
-   * which can be passed as `markdown_ref` to `client.v2.extract` /
-   * `client.v2.extractJobs.create`. Served on the ADE host under `/v1/files`.
+   * Stage a file's bytes on the ADE data plane and return a `file_ref` string.
+   * Served on the ADE host under `/v1/files`.
    */
   async upload(body: FileUploadParams, options?: RequestOptions): Promise<string> {
     const response = await this._client.post<V2FileUploadResponse>(

--- a/src/resources/v2/v2.ts
+++ b/src/resources/v2/v2.ts
@@ -54,9 +54,8 @@ export class V2 extends V2Resource {
   /**
    * Extract structured data from markdown synchronously (`POST /v2/extract`,
    * JSON body). `schema` accepts a JSON-Schema object or a JSON-encoded string.
-   * Provide exactly one of `markdown`, `markdown_ref`, or `markdown_url`.
-   * Rejects with `V2SyncTimeoutError` on a 504; use `extractJobs` for
-   * long-running documents.
+   * Provide exactly one of `markdown` or `markdown_url`. Rejects with
+   * `V2SyncTimeoutError` on a 504; use `extractJobs` for long-running documents.
    */
   async extract(
     body: V2ExtractParams & { saveTo?: string },

--- a/src/resources/v2/workflow.ts
+++ b/src/resources/v2/workflow.ts
@@ -57,8 +57,6 @@ export interface V2WorkflowParams {
 
   /** Optional projection map: response field name → `"$output.<step>.<field>..."`. */
   output?: Record<string, string> | null;
-
-  idempotency_key?: string | null;
 }
 
 export interface V2WorkflowJobCreateParams extends V2WorkflowParams {
@@ -101,7 +99,6 @@ export function prepareWorkflowRequest(params: V2WorkflowJobCreateParams): Prepa
   if (files.length === 0) {
     const body: Record<string, unknown> = { inputs: resolvedInputs, steps: params.steps };
     if (params.output != null) body['output'] = params.output;
-    if (params.idempotency_key != null) body['idempotency_key'] = params.idempotency_key;
     if (params.service_tier != null) body['service_tier'] = params.service_tier;
     return { multipart: false, body };
   }
@@ -112,7 +109,6 @@ export function prepareWorkflowRequest(params: V2WorkflowJobCreateParams): Prepa
     steps: JSON.stringify(params.steps),
   };
   if (params.output != null) form['output'] = JSON.stringify(params.output);
-  if (params.idempotency_key != null) form['idempotency_key'] = params.idempotency_key;
   if (params.service_tier != null) form['service_tier'] = params.service_tier;
   for (const [name, file] of files) form[name] = file;
   return { multipart: true, body: form };


### PR DESCRIPTION
Mirrors landing-ai/ade-python#111. A check of `client.v2` against the live AIDE spec surfaced request parameters the API no longer accepts.

**Verified against the live AIDE spec** (`aide.landing.ai/openapi.json`):
- `/v2/extract` & `/v2/extract/jobs` → `schema` (required), `markdown`, `markdown_url`, `model`, `options` (+ `service_tier` on jobs). **No `markdown_ref`, no `idempotency_key`.**
- `/v2/workflow` & `/v2/workflow/jobs` → `inputs`, `steps`, `output` (+ `service_tier`). **No `idempotency_key`.**

**Changes**
- Remove `markdown_ref` + `idempotency_key` from `client.v2.extract` / `extractJobs.create` (`V2ExtractParams`, `buildExtractBody`).
- Remove `idempotency_key` from `client.v2.workflow` / `workflowJobs.create`. *(ade-python#111 didn't touch workflow — that repo defers the workflow surface; ade-typescript ships it, so this is a TS-specific hit.)*
- Reword the `files.upload` docstring and drop the README "File staging" section (both showed the removed `markdown_ref` flow). `/v1/files` / `files.upload` itself stays.
- `password` (parse), `service_tier`, `output_save_url` are all in the spec → untouched.

No released-surface break — `client.v2` is unreleased (added after `v2.7.0`). Typecheck clean; full suite 280 passed.

**Reference:** landing-ai/ade-python#111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)