### PR TITLE
fix(ci): pin npm publish to registry.npmjs.org

### DIFF
--- a/bin/publish-npm
+++ b/bin/publish-npm
@@ -66,5 +66,9 @@ fi
 npm install -g npm@11.6.2
 
 # Publish with the appropriate tag
+# yarn run injects npm_config_registry=https://registry.yarnpkg.com into child
+# processes; npm auth and OIDC Trusted Publishing are scoped to
+# registry.npmjs.org, so publishing dies with ENEEDAUTH unless we pin it back.
+export npm_config_registry='https://registry.npmjs.org'
 # --provenance triggers OIDC authentication with npm Trusted Publishing
 npm publish --tag "$TAG" --provenance --access public


### PR DESCRIPTION
## Why

`landingai-ade@2.8.0` never reached npm: the release-triggered [Publish NPM run](https://github.com/landing-ai/ade-typescript/actions/runs/29359108699) failed with

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.yarnpkg.com
```

The publish step runs through `yarn tsn scripts/publish-packages.ts`, and yarn 1.x exports `npm_config_registry=https://registry.yarnpkg.com` into every child process (env-level npm config outranks the `.npmrc` that `actions/setup-node` writes). npm auth and OIDC Trusted Publishing are scoped to `registry.npmjs.org`, so `npm publish` dies against the yarn mirror before any credential exchange can happen.

`bin/publish-npm` carried exactly this export until the template refresh in #70 dropped it ([v2.7.0's version](https://github.com/landing-ai/ade-typescript/blob/v2.7.0/bin/publish-npm)). Note the workflow has *never* had working registry-side auth — every `publish-npm.yml` run in history failed `ENEEDAUTH` and Stainless's managed pipeline did the real publishing out-of-band — but post-sunset this workflow is the only publish path, so it has to work now.

## What this does / doesn't fix

- ✅ npm targets `registry.npmjs.org` again, so the `--provenance` OIDC exchange can engage
- ⚠️ Still requires a Trusted Publisher configured on npmjs.com for **both** `landingai-ade` and `landingai-ade-mcp` (repo `landing-ai/ade-typescript`, workflow `publish-npm.yml`) — being done separately

## Re-publish plan for 2.8.0

After merge + trusted-publisher config: dispatch **Publish NPM** twice (`path: .`, `path: packages/mcp-server`) — main's HEAD is the `release: 2.8.0` commit, so it publishes 2.8.0. Then attach the DXT asset to the v2.8.0 release manually (that upload step is release-event-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)