### PR TITLE
fix(ci): escape inner quotes in the dispatch-path publish payload

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -36,7 +36,10 @@ jobs:
       - name: Publish to NPM
         run: |
           if [ -n "$INPUT_PATH" ]; then
-            PATHS_RELEASED="[\"$INPUT_PATH\"]"
+            # The inner quotes must survive into the payload as literal \" —
+            # paths_released is a JSON string containing JSON, like the else
+            # branch. Unescaped quotes make the payload unparseable.
+            PATHS_RELEASED="[\\\"$INPUT_PATH\\\"]"
           else
             PATHS_RELEASED='[\".\", \"packages/mcp-server\"]'
           fi


### PR DESCRIPTION
## Why

The manual re-publish dispatch ([run 29364934237](https://github.com/landing-ai/ade-typescript/actions/runs/29364934237), attempting to ship the stuck `v2.8.0`) failed before reaching npm:

```
publish-packages called with { "paths_released": "["."]" }
SyntaxError: Expected ',' or '}' after property value in JSON at position 23
```

`publish-packages.ts` expects `paths_released` to be a JSON string *containing* JSON, so the inner quotes must arrive escaped. The release-event branch does this (`[\".\", \"packages/mcp-server\"]`); the `workflow_dispatch` branch interpolated raw quotes, making the payload unparseable — the documented manual re-publish path has never actually worked.

## Fix

Escape the inner quotes in the dispatch branch to match the release branch. Verified locally through both `JSON.parse` layers:

```
payload: { "paths_released": "[\".\"]" }
outer OK, inner: [ '.' ] ARRAY OK
```

## Context

Second and final blocker for re-publishing 2.8.0 after #78 (registry pin). After merge: dispatch **Publish NPM** with `path: .` (root package only — mcp-server is being deprecated and skipped deliberately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)