### PR TITLE
spec-sync: track V2 spec drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ for (const j of jobs.jobs) {
 console.log(jobs.has_more);
 ```
 
-Extract jobs work the same way. The `create` method takes the same schema and Markdown arguments as `client.v2.extract`, plus `service_tier`; it does not accept `saveTo`.
+Extract jobs work the same way. The `create` method takes the same schema and Markdown arguments as `client.v2.extract`, plus `service_tier` and `output_save_url`; it does not accept `saveTo`. Set `output_save_url` to a public http(s) URL (e.g. a presigned S3 PUT URL) to have the finished result delivered there instead of inline — the completed job then reports `output_url` on `job.raw` in place of `result`.
 
 ## Environments
 

--- a/specs/_generated/v2-aide.d.ts
+++ b/specs/_generated/v2-aide.d.ts
@@ -368,6 +368,13 @@ export interface components {
              */
             type: "text" | "table" | "table_cell" | "figure" | "marginalia" | "attestation" | "logo" | "card" | "scan_code";
         };
+        /** ErrorResponse */
+        ErrorResponse: {
+            /** @description Stable snake_case error code (e.g. ``validation_error``, ``unknown_model_version``, ``invalid_url``, ``invalid_api_key``, ``rate_limit_exceeded``). */
+            code: string;
+            /** @description Human-readable detail. */
+            message: string;
+        };
         /** FigureOptions */
         FigureOptions: {
             /**
@@ -599,18 +606,6 @@ export interface components {
          */
         V2Billing: {
             /**
-             * Input Markdown Chars
-             * @description Characters (Unicode code points) in the input markdown as submitted — the input basis of the credit charge. Extract responses only.
-             * @default null
-             */
-            input_markdown_chars: number | null;
-            /**
-             * Output Extraction Chars
-             * @description Characters in the serialized extraction output — the output basis of the credit charge. Extract responses only.
-             * @default null
-             */
-            output_extraction_chars: number | null;
-            /**
              * Service Tier
              * @description The service tier the request ran in: `standard` or `priority`. A sync request reports `priority` (same lane, same price).
              * @default null
@@ -631,12 +626,6 @@ export interface components {
             /** @description Billing summary: the service tier the request ran in and the credits charged. */
             billing?: components["schemas"]["V2Billing"] | null;
             /**
-             * Credit Usage
-             * @description Credits billed for this request.
-             * @default 0
-             */
-            credit_usage: number;
-            /**
              * Doc Id
              * @description Present when the input markdown contained a ``<!-- doc_id=<id> -->`` comment (embedded by ``POST /v2/parse``). Links this extract call to the originating parse job.
              * @default null
@@ -647,6 +636,12 @@ export interface components {
              * @description End-to-end request duration in milliseconds.
              */
             duration_ms: number;
+            /**
+             * Input Markdown Chars
+             * @description Characters (Unicode code points) in the input markdown as submitted — the input basis of the credit charge.
+             * @default null
+             */
+            input_markdown_chars: number | null;
             /**
              * Job Id
              * @description Gateway job id (workflow id). Matches the ``x-request-id`` the gateway minted for this request and the billing row id in vision-agent.
@@ -659,6 +654,12 @@ export interface components {
             model_version: string;
             /** @description URL of the OpenAPI spec covering this API, for inspection and client generation. */
             openapi_spec: string;
+            /**
+             * Output Extraction Chars
+             * @description Characters in the serialized extraction output — the output basis of the credit charge.
+             * @default null
+             */
+            output_extraction_chars: number | null;
             /**
              * Range Units
              * @description Units of every `range` offset in the response. Always `"unicode_codepoints"` (Unicode code points into `markdown`). Declared explicitly so consumers know how to slice the string — e.g. JavaScript strings are UTF-16, so a naive `.slice()` drifts when the markdown contains astral characters.
@@ -674,7 +675,7 @@ export interface components {
         V2ExtractOptions: {
             /**
              * Strict
-             * @description When ``true``, returns HTTP 422 if the schema contains fields the model cannot extract. When ``false`` (default), unsupported fields are skipped and extraction continues.
+             * @description When ``true``, a schema containing fields the model cannot extract fails with a validation error — HTTP 422 on the sync route, or a failed job (``status: "failed"``) on the async ``/jobs`` route. When ``false`` (default), unsupported fields are skipped and extraction continues.
              * @default false
              */
             strict: boolean;
@@ -687,12 +688,6 @@ export interface components {
         V2WorkflowMetadata: {
             /** @description Billing summary: the service tier the request ran in and the credits charged. */
             billing?: components["schemas"]["V2Billing"] | null;
-            /**
-             * Credit Usage
-             * @description Combined credits billed for this request (parse + extract).
-             * @default 0
-             */
-            credit_usage: number;
             /**
              * Duration Ms
              * @description Total end-to-end duration across all stages in milliseconds.
@@ -761,7 +756,7 @@ export interface components {
             pages: number[] | null;
             /**
              * Strict
-             * @description When ``true``, returns 422 if the schema contains fields the model cannot extract. When ``false``, unsupported fields are skipped.
+             * @description When ``true``, a schema containing fields the model cannot extract fails with a validation error — HTTP 422 on the sync route, or a failed job on the async ``/jobs`` route. When ``false``, unsupported fields are skipped.
              * @default false
              */
             strict: boolean;
@@ -933,23 +928,31 @@ export interface operations {
                          * @description Echoed input markdown.
                          */
                         markdown: string;
-                        /** @description Request metadata (job_id, model_version, duration_ms, doc_id, credit_usage). */
+                        /** @description Request metadata (job_id, model_version, duration_ms, doc_id, billing). */
                         metadata: components["schemas"]["V2ExtractMetadata"];
                         /**
-                         * Output Ref
+                         * Schema Violation Error
+                         * @description Set when ``options.strict`` is false and the schema contained fields the model could not extract — the extraction is partial.
                          * @default null
                          */
-                        output_ref: string | null;
+                        schema_violation_error: string | null;
+                        /**
+                         * Warnings
+                         * @description Non-fatal warnings emitted during extraction.
+                         */
+                        warnings?: {
+                            [key: string]: unknown;
+                        }[];
                     };
                 };
             };
-            /** @description Validation Error */
+            /** @description Request validation failed. */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
         };
@@ -993,13 +996,13 @@ export interface operations {
                     };
                 };
             };
-            /** @description Validation Error */
+            /** @description Request validation failed. */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
         };
@@ -1037,6 +1040,12 @@ export interface operations {
                      * @default null
                      */
                     options?: components["schemas"]["V2ExtractOptions"] | null;
+                    /**
+                     * Output Save Url
+                     * @description URL to save the result to — e.g. a presigned S3 PUT URL. Async jobs only. When set, the finished result is delivered (HTTP PUT) to this URL and the completed job reports ``output_url`` instead of an inline ``result``. Must be a public http(s) URL; private/loopback IPs are rejected at submit time.
+                     * @default null
+                     */
+                    output_save_url?: string | null;
                     /**
                      * Schema
                      * @description JSON Schema describing the fields to extract. The schema must be an object type with a ``properties`` map of field names to their types and descriptions.
@@ -1080,6 +1089,12 @@ export interface operations {
                      */
                     options?: components["schemas"]["V2ExtractOptions"] | null;
                     /**
+                     * Output Save Url
+                     * @description URL to save the result to — e.g. a presigned S3 PUT URL. Async jobs only. When set, the finished result is delivered (HTTP PUT) to this URL and the completed job reports ``output_url`` instead of an inline ``result``. Must be a public http(s) URL; private/loopback IPs are rejected at submit time. JSON-serialized string in form data.
+                     * @default null
+                     */
+                    output_save_url?: string | null;
+                    /**
                      * Schema
                      * @description JSON Schema describing the fields to extract. The schema must be an object type with a ``properties`` map of field names to their types and descriptions. JSON-serialized string in form data.
                      * @example {
@@ -1120,6 +1135,15 @@ export interface operations {
                     };
                 };
             };
+            /** @description Request validation failed. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
         };
     };
     "v2-extract_get_job": {
@@ -1152,9 +1176,11 @@ export interface operations {
                         };
                         /** @description The unique identifier for this v2-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
                         job_id?: string;
-                        /** @description Best-effort progress, present while processing only for jobs that report it. */
-                        progress?: unknown;
-                        /** @description Present once status is ``completed``. */
+                        /** @description The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``. */
+                        output_url?: string | null;
+                        /** @description Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``. */
+                        progress?: number;
+                        /** @description Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead. */
                         result?: {
                             /**
                              * Extraction
@@ -1175,26 +1201,43 @@ export interface operations {
                              * @description Echoed input markdown.
                              */
                             markdown: string;
-                            /** @description Request metadata (job_id, model_version, duration_ms, doc_id, credit_usage). */
+                            /** @description Request metadata (job_id, model_version, duration_ms, doc_id, billing). */
                             metadata: components["schemas"]["V2ExtractMetadata"];
                             /**
-                             * Output Ref
+                             * Schema Violation Error
+                             * @description Set when ``options.strict`` is false and the schema contained fields the model could not extract — the extraction is partial.
                              * @default null
                              */
-                            output_ref: string | null;
+                            schema_violation_error: string | null;
+                            /**
+                             * Warnings
+                             * @description Non-fatal warnings emitted during extraction.
+                             */
+                            warnings?: {
+                                [key: string]: unknown;
+                            }[];
                         } | null;
                         /** @enum {string} */
                         status?: "pending" | "processing" | "completed" | "failed";
                     };
                 };
             };
-            /** @description Validation Error */
+            /** @description Not found (e.g. no such job). */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Request validation failed. */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
         };
@@ -1270,13 +1313,13 @@ export interface operations {
                     "application/json": components["schemas"]["ParseResponse"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Request validation failed. */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
         };
@@ -1316,13 +1359,13 @@ export interface operations {
                             failure_reason?: string | null;
                             /** @description The unique identifier for the parse job. Format: ``<service>-<26-character Crockford base32 ULID>`` matching ``^(parse|extract)-[0-9a-hjkmnp-tv-z]{26}$``. Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
                             job_id?: string;
+                            /** @description The model snapshot used to parse the document. */
+                            model_version?: string | null;
                             /**
                              * @description The job's current status: ``pending``, ``processing``, ``completed``, or ``failed``.
                              * @enum {string}
                              */
                             status?: "pending" | "processing" | "completed" | "failed";
-                            /** @description The model snapshot used to parse the document. */
-                            version?: string | null;
                         }[];
                         /** @description The 0-indexed page number. */
                         page?: number;
@@ -1331,13 +1374,13 @@ export interface operations {
                     };
                 };
             };
-            /** @description Validation Error */
+            /** @description Request validation failed. */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
         };
@@ -1421,6 +1464,15 @@ export interface operations {
                     };
                 };
             };
+            /** @description Request validation failed. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
         };
     };
     parse_get_job: {
@@ -1473,15 +1525,17 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
             };
-            /** @description Validation Error */
+            /** @description Request validation failed. */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
         };
@@ -1595,7 +1649,7 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        /** @description Request metadata (job_id, duration_ms, credit_usage). */
+                        /** @description Request metadata (job_id, duration_ms, billing). */
                         metadata: components["schemas"]["V2WorkflowMetadata"];
                         /**
                          * Output
@@ -1604,21 +1658,16 @@ export interface operations {
                         output: {
                             [key: string]: unknown;
                         };
-                        /**
-                         * Output Ref
-                         * @default null
-                         */
-                        output_ref: string | null;
                     };
                 };
             };
-            /** @description Validation Error */
+            /** @description Request validation failed. */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
         };
@@ -1662,13 +1711,13 @@ export interface operations {
                     };
                 };
             };
-            /** @description Validation Error */
+            /** @description Request validation failed. */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
         };
@@ -1794,6 +1843,15 @@ export interface operations {
                     };
                 };
             };
+            /** @description Request validation failed. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
         };
     };
     "v2-workflow_get_job": {
@@ -1826,11 +1884,11 @@ export interface operations {
                         };
                         /** @description The unique identifier for this v2-workflow job. Format: ``v2-workflow-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
                         job_id?: string;
-                        /** @description Best-effort progress, present while processing only for jobs that report it. */
-                        progress?: unknown;
+                        /** @description Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``. */
+                        progress?: number;
                         /** @description Present once status is ``completed``. */
                         result?: {
-                            /** @description Request metadata (job_id, duration_ms, credit_usage). */
+                            /** @description Request metadata (job_id, duration_ms, billing). */
                             metadata: components["schemas"]["V2WorkflowMetadata"];
                             /**
                              * Output
@@ -1839,24 +1897,28 @@ export interface operations {
                             output: {
                                 [key: string]: unknown;
                             };
-                            /**
-                             * Output Ref
-                             * @default null
-                             */
-                            output_ref: string | null;
                         } | null;
                         /** @enum {string} */
                         status?: "pending" | "processing" | "completed" | "failed";
                     };
                 };
             };
-            /** @description Validation Error */
+            /** @description Not found (e.g. no such job). */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Request validation failed. */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
         };

--- a/specs/v2-aide.json
+++ b/specs/v2-aide.json
@@ -2,6 +2,7 @@
   "components": {
     "schemas": {
       "BaseElementOptions": {
+        "additionalProperties": false,
         "properties": {
           "markdown": {
             "default": true,
@@ -13,6 +14,7 @@
         "type": "object"
       },
       "BlocksOptions": {
+        "additionalProperties": false,
         "properties": {
           "attestation": {
             "$ref": "#/components/schemas/BaseElementOptions"
@@ -257,7 +259,26 @@
         "title": "Element",
         "type": "object"
       },
+      "ErrorResponse": {
+        "properties": {
+          "code": {
+            "description": "Stable snake_case error code (e.g. ``validation_error``, ``unknown_model_version``, ``invalid_url``, ``invalid_api_key``, ``rate_limit_exceeded``).",
+            "type": "string"
+          },
+          "message": {
+            "description": "Human-readable detail.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "title": "ErrorResponse",
+        "type": "object"
+      },
       "FigureOptions": {
+        "additionalProperties": false,
         "properties": {
           "markdown": {
             "default": true,
@@ -606,6 +627,7 @@
         "type": "object"
       },
       "TableOptions": {
+        "additionalProperties": false,
         "properties": {
           "format": {
             "default": "html",
@@ -628,32 +650,6 @@
       "V2Billing": {
         "description": "Billing summary: the service tier the request ran in and the credits\ncharged.",
         "properties": {
-          "input_markdown_chars": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Characters (Unicode code points) in the input markdown as submitted — the input basis of the credit charge. Extract responses only.",
-            "title": "Input Markdown Chars"
-          },
-          "output_extraction_chars": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Characters in the serialized extraction output — the output basis of the credit charge. Extract responses only.",
-            "title": "Output Extraction Chars"
-          },
           "service_tier": {
             "anyOf": [
               {
@@ -702,12 +698,6 @@
             ],
             "description": "Billing summary: the service tier the request ran in and the credits charged."
           },
-          "credit_usage": {
-            "default": 0.0,
-            "description": "Credits billed for this request.",
-            "title": "Credit Usage",
-            "type": "number"
-          },
           "doc_id": {
             "anyOf": [
               {
@@ -726,6 +716,19 @@
             "title": "Duration Ms",
             "type": "integer"
           },
+          "input_markdown_chars": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Characters (Unicode code points) in the input markdown as submitted — the input basis of the credit charge.",
+            "title": "Input Markdown Chars"
+          },
           "job_id": {
             "description": "Gateway job id (workflow id). Matches the ``x-request-id`` the gateway minted for this request and the billing row id in vision-agent.",
             "title": "Job Id",
@@ -739,6 +742,19 @@
           "openapi_spec": {
             "description": "URL of the OpenAPI spec covering this API, for inspection and client generation.",
             "type": "string"
+          },
+          "output_extraction_chars": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Characters in the serialized extraction output — the output basis of the credit charge.",
+            "title": "Output Extraction Chars"
           },
           "range_units": {
             "const": "unicode_codepoints",
@@ -759,11 +775,12 @@
         "type": "object"
       },
       "V2ExtractOptions": {
+        "additionalProperties": false,
         "description": "Extraction options (``docs/extract-v2-proposal.md`` → Options).",
         "properties": {
           "strict": {
             "default": false,
-            "description": "When ``true``, returns HTTP 422 if the schema contains fields the model cannot extract. When ``false`` (default), unsupported fields are skipped and extraction continues.",
+            "description": "When ``true``, a schema containing fields the model cannot extract fails with a validation error — HTTP 422 on the sync route, or a failed job (``status: \"failed\"``) on the async ``/jobs`` route. When ``false`` (default), unsupported fields are skipped and extraction continues.",
             "title": "Strict",
             "type": "boolean"
           }
@@ -784,12 +801,6 @@
               }
             ],
             "description": "Billing summary: the service tier the request ran in and the credits charged."
-          },
-          "credit_usage": {
-            "default": 0.0,
-            "description": "Combined credits billed for this request (parse + extract).",
-            "title": "Credit Usage",
-            "type": "number"
           },
           "duration_ms": {
             "description": "Total end-to-end duration across all stages in milliseconds.",
@@ -910,7 +921,7 @@
           },
           "strict": {
             "default": false,
-            "description": "When ``true``, returns 422 if the schema contains fields the model cannot extract. When ``false``, unsupported fields are skipped.",
+            "description": "When ``true``, a schema containing fields the model cannot extract fails with a validation error — HTTP 422 on the sync route, or a failed job on the async ``/jobs`` route. When ``false``, unsupported fields are skipped.",
             "title": "Strict",
             "type": "boolean"
           }
@@ -1170,9 +1181,9 @@
                     },
                     "metadata": {
                       "$ref": "#/components/schemas/V2ExtractMetadata",
-                      "description": "Request metadata (job_id, model_version, duration_ms, doc_id, credit_usage)."
+                      "description": "Request metadata (job_id, model_version, duration_ms, doc_id, billing)."
                     },
-                    "output_ref": {
+                    "schema_violation_error": {
                       "anyOf": [
                         {
                           "type": "string"
@@ -1182,7 +1193,17 @@
                         }
                       ],
                       "default": null,
-                      "title": "Output Ref"
+                      "description": "Set when ``options.strict`` is false and the schema contained fields the model could not extract — the extraction is partial.",
+                      "title": "Schema Violation Error"
+                    },
+                    "warnings": {
+                      "description": "Non-fatal warnings emitted during extraction.",
+                      "items": {
+                        "additionalProperties": true,
+                        "type": "object"
+                      },
+                      "title": "Warnings",
+                      "type": "array"
                     }
                   },
                   "required": [
@@ -1202,11 +1223,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             },
-            "description": "Validation Error"
+            "description": "Request validation failed."
           }
         },
         "summary": "ADE Extract",
@@ -1337,11 +1358,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             },
-            "description": "Validation Error"
+            "description": "Request validation failed."
           }
         },
         "summary": "ADE List Extract Jobs",
@@ -1408,6 +1429,19 @@
                     ],
                     "default": null,
                     "description": "Extraction options (``strict``). Omit for defaults."
+                  },
+                  "output_save_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "URL to save the result to — e.g. a presigned S3 PUT URL. Async jobs only. When set, the finished result is delivered (HTTP PUT) to this URL and the completed job reports ``output_url`` instead of an inline ``result``. Must be a public http(s) URL; private/loopback IPs are rejected at submit time.",
+                    "title": "Output Save Url"
                   },
                   "schema": {
                     "additionalProperties": true,
@@ -1505,6 +1539,19 @@
                     "default": null,
                     "description": "Extraction options (``strict``). Omit for defaults. JSON-serialized string in form data."
                   },
+                  "output_save_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "URL to save the result to — e.g. a presigned S3 PUT URL. Async jobs only. When set, the finished result is delivered (HTTP PUT) to this URL and the completed job reports ``output_url`` instead of an inline ``result``. Must be a public http(s) URL; private/loopback IPs are rejected at submit time. JSON-serialized string in form data.",
+                    "title": "Output Save Url"
+                  },
                   "schema": {
                     "additionalProperties": true,
                     "description": "JSON Schema describing the fields to extract. The schema must be an object type with a ``properties`` map of field names to their types and descriptions. JSON-serialized string in form data.",
@@ -1580,6 +1627,16 @@
               }
             },
             "description": "Job created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
           }
         },
         "summary": "ADE Extract Jobs",
@@ -1638,8 +1695,18 @@
                       "description": "The unique identifier for this v2-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
                       "type": "string"
                     },
+                    "output_url": {
+                      "description": "The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
                     "progress": {
-                      "description": "Best-effort progress, present while processing only for jobs that report it."
+                      "description": "Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``.",
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
                     },
                     "result": {
                       "anyOf": [
@@ -1665,9 +1732,9 @@
                             },
                             "metadata": {
                               "$ref": "#/components/schemas/V2ExtractMetadata",
-                              "description": "Request metadata (job_id, model_version, duration_ms, doc_id, credit_usage)."
+                              "description": "Request metadata (job_id, model_version, duration_ms, doc_id, billing)."
                             },
-                            "output_ref": {
+                            "schema_violation_error": {
                               "anyOf": [
                                 {
                                   "type": "string"
@@ -1677,7 +1744,17 @@
                                 }
                               ],
                               "default": null,
-                              "title": "Output Ref"
+                              "description": "Set when ``options.strict`` is false and the schema contained fields the model could not extract — the extraction is partial.",
+                              "title": "Schema Violation Error"
+                            },
+                            "warnings": {
+                              "description": "Non-fatal warnings emitted during extraction.",
+                              "items": {
+                                "additionalProperties": true,
+                                "type": "object"
+                              },
+                              "title": "Warnings",
+                              "type": "array"
                             }
                           },
                           "required": [
@@ -1693,7 +1770,7 @@
                           "type": "null"
                         }
                       ],
-                      "description": "Present once status is ``completed``."
+                      "description": "Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead."
                     },
                     "status": {
                       "enum": [
@@ -1711,15 +1788,25 @@
             },
             "description": "Job status / result"
           },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found (e.g. no such job)."
+          },
           "422": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             },
-            "description": "Validation Error"
+            "description": "Request validation failed."
           }
         },
         "summary": "ADE Get Extract Jobs",
@@ -1751,6 +1838,7 @@
                     "type": "string"
                   },
                   "options": {
+                    "additionalProperties": false,
                     "description": "Optional object that customizes the parse. Use it to select which pages to process, adjust how content appears in the Markdown, or control how much detail the response includes. Sent as a JSON-serialized string in form data.",
                     "properties": {
                       "atomic_grounding": {
@@ -1832,11 +1920,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             },
-            "description": "Validation Error"
+            "description": "Request validation failed."
           }
         },
         "summary": "ADE Parse",
@@ -1934,6 +2022,13 @@
                             "description": "The unique identifier for the parse job. Format: ``<service>-<26-character Crockford base32 ULID>`` matching ``^(parse|extract)-[0-9a-hjkmnp-tv-z]{26}$``. Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
                             "type": "string"
                           },
+                          "model_version": {
+                            "description": "The model snapshot used to parse the document.",
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
                           "status": {
                             "description": "The job's current status: ``pending``, ``processing``, ``completed``, or ``failed``.",
                             "enum": [
@@ -1943,13 +2038,6 @@
                               "failed"
                             ],
                             "type": "string"
-                          },
-                          "version": {
-                            "description": "The model snapshot used to parse the document.",
-                            "type": [
-                              "string",
-                              "null"
-                            ]
                           }
                         },
                         "type": "object"
@@ -1975,11 +2063,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             },
-            "description": "Validation Error"
+            "description": "Request validation failed."
           }
         },
         "summary": "ADE List Parse Jobs",
@@ -2009,6 +2097,7 @@
                     "type": "string"
                   },
                   "options": {
+                    "additionalProperties": false,
                     "description": "Optional object that customizes the parse. Use it to select which pages to process, adjust how content appears in the Markdown, or control how much detail the response includes. Sent as a JSON-serialized string in form data.",
                     "properties": {
                       "atomic_grounding": {
@@ -2115,6 +2204,16 @@
               }
             },
             "description": "Job created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
           }
         },
         "summary": "ADE Parse Jobs",
@@ -2214,17 +2313,24 @@
             "description": "Job status / result"
           },
           "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
             "description": "Job not found"
           },
           "422": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             },
-            "description": "Validation Error"
+            "description": "Request validation failed."
           }
         },
         "summary": "ADE Get Parse Jobs",
@@ -2385,25 +2491,13 @@
                   "properties": {
                     "metadata": {
                       "$ref": "#/components/schemas/V2WorkflowMetadata",
-                      "description": "Request metadata (job_id, duration_ms, credit_usage)."
+                      "description": "Request metadata (job_id, duration_ms, billing)."
                     },
                     "output": {
                       "additionalProperties": true,
                       "description": "Step results keyed by step name, or a caller-defined projection. For ``parse-extract`` with no projection: ``{\"parse-extract\": {parse, extract, ground}}``.",
                       "title": "Output",
                       "type": "object"
-                    },
-                    "output_ref": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Output Ref"
                     }
                   },
                   "required": [
@@ -2421,11 +2515,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             },
-            "description": "Validation Error"
+            "description": "Request validation failed."
           }
         },
         "summary": "Run v2-workflow (sync)",
@@ -2555,11 +2649,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             },
-            "description": "Validation Error"
+            "description": "Request validation failed."
           }
         },
         "summary": "List v2-workflow jobs",
@@ -2769,6 +2863,16 @@
               }
             },
             "description": "Job created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
           }
         },
         "summary": "Create v2-workflow job",
@@ -2828,7 +2932,10 @@
                       "type": "string"
                     },
                     "progress": {
-                      "description": "Best-effort progress, present while processing only for jobs that report it."
+                      "description": "Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``.",
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
                     },
                     "result": {
                       "anyOf": [
@@ -2837,25 +2944,13 @@
                           "properties": {
                             "metadata": {
                               "$ref": "#/components/schemas/V2WorkflowMetadata",
-                              "description": "Request metadata (job_id, duration_ms, credit_usage)."
+                              "description": "Request metadata (job_id, duration_ms, billing)."
                             },
                             "output": {
                               "additionalProperties": true,
                               "description": "Step results keyed by step name, or a caller-defined projection. For ``parse-extract`` with no projection: ``{\"parse-extract\": {parse, extract, ground}}``.",
                               "title": "Output",
                               "type": "object"
-                            },
-                            "output_ref": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ],
-                              "default": null,
-                              "title": "Output Ref"
                             }
                           },
                           "required": [
@@ -2887,15 +2982,25 @@
             },
             "description": "Job status / result"
           },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found (e.g. no such job)."
+          },
           "422": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             },
-            "description": "Validation Error"
+            "description": "Request validation failed."
           }
         },
         "summary": "Get v2-workflow job",

--- a/src/resources/v2/extract.ts
+++ b/src/resources/v2/extract.ts
@@ -39,6 +39,15 @@ export interface V2ExtractParams {
 
 export interface V2ExtractJobCreateParams extends V2ExtractParams {
   /**
+   * URL to save the result to — e.g. a presigned S3 PUT URL. Async jobs only.
+   * When set, the finished result is delivered (HTTP PUT) to this URL and the
+   * completed job reports `output_url` (on `Job.raw`) instead of an inline
+   * `result`. Must be a public http(s) URL; private/loopback IPs are rejected at
+   * submit time.
+   */
+  output_save_url?: string | null;
+
+  /**
    * Async service tier. `priority` runs in the fast lane at the sync billing
    * rate; absent → `standard`.
    */
@@ -51,6 +60,7 @@ export function buildExtractBody(params: V2ExtractJobCreateParams): Record<strin
     ['markdown', params.markdown],
     ['markdown_url', params.markdown_url],
     ['model', params.model],
+    ['output_save_url', params.output_save_url],
     ['service_tier', params.service_tier],
   ];
   for (const [key, value] of entries) {

--- a/src/resources/v2/types.ts
+++ b/src/resources/v2/types.ts
@@ -267,6 +267,20 @@ export interface V2ExtractMetadata {
   billing?: V2Billing | null;
 
   /**
+   * Characters (Unicode code points) in the input markdown as submitted — the
+   * input basis of the credit charge. Spec moved this from `billing` onto the
+   * metadata; both locations are surfaced.
+   */
+  input_markdown_chars?: number | null;
+
+  /**
+   * Characters in the serialized extraction output — the output basis of the
+   * credit charge. Spec moved this from `billing` onto the metadata; both
+   * locations are surfaced.
+   */
+  output_extraction_chars?: number | null;
+
+  /**
    * Units of every `range` offset in the response. Always `unicode_codepoints`
    * (Unicode code points into `markdown`).
    */
@@ -287,6 +301,16 @@ export interface V2ExtractResult {
 
   /** Present when the output was delivered out-of-band (e.g. a ZDR save URL) instead of inline. */
   output_ref?: string | null;
+
+  /**
+   * Set when `options.strict` is false and the schema contained fields the model
+   * could not extract — the extraction is partial. Spec renamed `output_ref` →
+   * `schema_violation_error`; both are surfaced.
+   */
+  schema_violation_error?: string | null;
+
+  /** Non-fatal warnings emitted during extraction. */
+  warnings?: Array<Record<string, unknown>>;
 }
 
 // ---- Workflow ----

--- a/tests/api-resources/v2/v2.test.ts
+++ b/tests/api-resources/v2/v2.test.ts
@@ -247,6 +247,48 @@ describe('client.v2 routing', () => {
     expect(JSON.parse(String(sentBody))).toMatchObject({ service_tier: 'priority' });
   });
 
+  test('extractJobs.create sends output_save_url in the JSON body', async () => {
+    let sentBody: unknown;
+    const fetch: Fetch = async (_input, init) => {
+      sentBody = init?.body;
+      return jsonResponse({ job_id: 'ej-3' }, 202);
+    };
+    const client = new LandingAIADE({ apikey: 'k', environment: 'staging', maxRetries: 0, fetch });
+    const job = await client.v2.extractJobs.create({
+      schema: { type: 'object' },
+      markdown: 'hi',
+      output_save_url: 'https://example.com/put',
+    });
+    expect(job.job_id).toBe('ej-3');
+    expect(JSON.parse(String(sentBody))).toMatchObject({ output_save_url: 'https://example.com/put' });
+  });
+
+  test('extract (sync) surfaces schema_violation_error, warnings, and the moved billing counts', async () => {
+    const { client } = stubClient(() =>
+      jsonResponse({
+        extraction: { a: 1 },
+        extraction_metadata: {},
+        markdown: '# doc',
+        schema_violation_error: 'field `total` could not be extracted',
+        warnings: [{ code: 'partial', message: 'skipped a field' }],
+        metadata: {
+          job_id: 'j',
+          version: 'v',
+          model_version: 'dpt-3-pro-20260710',
+          duration_ms: 1,
+          input_markdown_chars: 10,
+          output_extraction_chars: 4,
+        },
+      }),
+    );
+    const res = await client.v2.extract({ schema: { type: 'object' }, markdown: 'hi' });
+    expect(res.schema_violation_error).toBe('field `total` could not be extracted');
+    expect(res.warnings?.[0]).toEqual({ code: 'partial', message: 'skipped a field' });
+    // Spec moved these two counts from `billing` onto the metadata itself.
+    expect(res.metadata.input_markdown_chars).toBe(10);
+    expect(res.metadata.output_extraction_chars).toBe(4);
+  });
+
   test('workflow (sync) routes to the V2 host and returns output + metadata', async () => {
     const { client, calls } = stubClient(() =>
       jsonResponse({

--- a/tests/contract/v2-smoke.test.ts
+++ b/tests/contract/v2-smoke.test.ts
@@ -38,6 +38,13 @@ describe('V2 contract (staging)', () => {
       // `version` was renamed to `model_version` in the metadata.
       expect(res.metadata.range_units).toBe('unicode_codepoints');
       expect(typeof res.metadata.model_version).toBe('string');
+      // Spec-sync moved the credit-charge character counts from `billing` onto
+      // the metadata itself; a non-strict extract also surfaces
+      // `schema_violation_error` (null when the schema was fully satisfied).
+      expect(
+        res.metadata.input_markdown_chars == null || typeof res.metadata.input_markdown_chars === 'number',
+      ).toBe(true);
+      expect(res.schema_violation_error === undefined || res.schema_violation_error === null).toBe(true);
     },
     60_000,
   );


### PR DESCRIPTION
Automated V2 spec-sync PR (`client.v2`).

- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference types.
- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff. The shipped-but-hand-maintained `/v2/workflow*` surface is not auto-wired, so workflow-only drift lands as a **mechanical-only PR** for a maintainer to reconcile by hand.

Gates (surface-lock, V2 contract tests, lint/build/test) must pass. The V2 ergonomic layer (unified Job, dual-host, schema coercion) is not in the spec, so when present the AI commit is a **draft a human finishes**. **Human review required before merge.**
<!-- spec-sync-nudged: 20654 -->
