### PR TITLE
feat(spec-sync): Phase 2 lifecycle notifications (gates, merge, aging)

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -1,20 +1,29 @@
 name: Slack notify
 description: >
-  Post a spec-sync status message to Slack via an incoming webhook. A silent
-  no-op when `webhook` is empty, so the workflow runs unchanged in forks and
-  before the secret is configured. Never fails the job: a Slack outage must not
-  turn a spec-sync run red.
+  Post a spec-sync status message to Slack. Prefers the Web API (chat.postMessage
+  with a bot token): that path can thread (via `thread_ts`) and returns the posted
+  message `ts` as an output. Falls back to an incoming webhook (flat, no ts) when
+  only `webhook` is set, and is a silent no-op when neither is configured. Never
+  fails the job: a Slack outage must not turn a spec-sync run red.
 
-  Renders a single mrkdwn section — put any links inline in `text` with Slack's
-  `<url|label>` syntax. Deliberately no buttons: an `actions`/`button` block is
-  an interactive component that requires the app to configure an Interactivity
-  Request URL, which a webhook-only app has not — Slack would warn "not
-  configured to handle interactive responses" on click. Inline links don't.
+  Renders a single mrkdwn section + a repo-context footer — put any links inline
+  in `text` with Slack's `<url|label>` syntax. Deliberately no buttons: a button
+  is an interactive component that needs an app Interactivity Request URL, which a
+  bot-token/webhook app has not (Slack warns "not configured to handle interactive
+  responses" on click). Inline links don't.
 inputs:
-  webhook:
-    description: Slack incoming webhook URL. Empty -> silent no-op.
+  bot_token:
+    description: Slack bot token (xoxb-...). When set, posts via chat.postMessage and can thread.
     required: false
     default: ''
+  webhook:
+    description: Incoming webhook URL. Used only when bot_token is empty (flat, no threading, no ts).
+    required: false
+    default: ''
+  channel:
+    description: Channel (name or ID) for chat.postMessage. Ignored in webhook mode.
+    required: false
+    default: '#ade-sdk-pipeline'
   status:
     description: success | warning | failure | info (drives the emoji only).
     required: true
@@ -24,47 +33,85 @@ inputs:
   text:
     description: Message body (Slack mrkdwn; use <url|label> for links).
     required: true
+  thread_ts:
+    description: When set (bot_token mode), post as a reply under this thread root.
+    required: false
+    default: ''
+  reply_broadcast:
+    description: "'true' to also surface a threaded reply back in the channel. Only with thread_ts."
+    required: false
+    default: 'false'
+outputs:
+  ts:
+    description: The posted message ts (empty in webhook mode, on no-op, or on failure).
+    value: ${{ steps.post.outputs.ts }}
 runs:
   using: composite
   steps:
-    - shell: bash
+    - id: post
+      shell: bash
       env:
+        BOT_TOKEN: ${{ inputs.bot_token }}
         WEBHOOK: ${{ inputs.webhook }}
+        CHANNEL: ${{ inputs.channel }}
         STATUS: ${{ inputs.status }}
         TITLE: ${{ inputs.title }}
         TEXT: ${{ inputs.text }}
+        THREAD_TS: ${{ inputs.thread_ts }}
+        REPLY_BROADCAST: ${{ inputs.reply_broadcast }}
       run: |
         set -euo pipefail
-        if [ -z "${WEBHOOK}" ]; then
-          echo "slack-notify: no webhook configured; skipping."
-          exit 0
-        fi
         case "${STATUS}" in
           success) emoji="✅" ;;
           warning) emoji="⚠️" ;;
           failure) emoji="🔴" ;;
           *)       emoji="ℹ️" ;;
         esac
-        # jq builds (and escapes) the Block Kit payload. jq is preinstalled on GitHub-hosted runners.
-        # GITHUB_REPOSITORY is a default env var the runner sets in every step (incl. composite
-        # actions), so the context footer names the source repo — ade-typescript vs ade-python — with
-        # no input to thread through and no per-repo config.
-        payload="$(jq -n \
+        # Shared blocks: a mrkdwn section + a repo-context footer. GITHUB_REPOSITORY is a default env
+        # var the runner sets in every step, so the footer names the source repo (ade-typescript vs
+        # ade-python) with no input to thread through. jq is preinstalled on GitHub-hosted runners.
+        blocks="$(jq -n \
           --arg header "${emoji} ${TITLE}" \
           --arg text "${TEXT}" \
           --arg repo "${GITHUB_REPOSITORY}" '
-          {
-            blocks: [
-              { type: "section",
-                text: { type: "mrkdwn", text: ("*" + $header + "*\n" + $text) } },
-              { type: "context",
-                elements: [ { type: "mrkdwn", text: ("📦 `" + $repo + "` · spec-sync") } ] }
-            ]
-          }')"
-        # Non-fatal by design: capture the HTTP status, never propagate a send failure.
-        code="$(curl -sS -o /dev/null -w '%{http_code}' \
-          -X POST -H 'Content-type: application/json' \
-          --data "${payload}" "${WEBHOOK}" || echo "000")"
-        if [ "${code}" != "200" ]; then
-          echo "slack-notify: webhook returned HTTP ${code} (non-fatal; continuing)."
+          [ { type: "section", text: { type: "mrkdwn", text: ("*" + $header + "*\n" + $text) } },
+            { type: "context", elements: [ { type: "mrkdwn", text: ("📦 `" + $repo + "` · spec-sync") } ] } ]')"
+
+        # Preferred: Web API. Returns the message ts (needed to thread later events) and accepts
+        # thread_ts to reply under an existing root.
+        if [ -n "${BOT_TOKEN}" ]; then
+          payload="$(jq -n \
+            --arg channel "${CHANNEL}" \
+            --arg fallback "${emoji} ${TITLE}" \
+            --argjson blocks "${blocks}" \
+            --arg thread "${THREAD_TS}" \
+            --arg broadcast "${REPLY_BROADCAST}" '
+            { channel: $channel, text: $fallback, blocks: $blocks }
+            + (if $thread != "" then { thread_ts: $thread } else {} end)
+            + (if $thread != "" and $broadcast == "true" then { reply_broadcast: true } else {} end)')"
+          resp="$(curl -sS -X POST \
+            -H "Authorization: Bearer ${BOT_TOKEN}" \
+            -H 'Content-type: application/json; charset=utf-8' \
+            --data "${payload}" https://slack.com/api/chat.postMessage \
+            || echo '{"ok":false,"error":"curl_failed"}')"
+          if [ "$(printf '%s' "${resp}" | jq -r '.ok')" = "true" ]; then
+            printf 'ts=%s\n' "$(printf '%s' "${resp}" | jq -r '.ts')" >> "$GITHUB_OUTPUT"
+          else
+            echo "slack-notify: chat.postMessage failed: $(printf '%s' "${resp}" | jq -r '.error // "unknown"') (non-fatal; continuing)."
+          fi
+          exit 0
         fi
+
+        # Fallback: incoming webhook. Flat only — returns no ts, so threading silently degrades.
+        if [ -n "${WEBHOOK}" ]; then
+          payload="$(jq -n --argjson blocks "${blocks}" '{ blocks: $blocks }')"
+          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -X POST -H 'Content-type: application/json' \
+            --data "${payload}" "${WEBHOOK}" || echo "000")"
+          if [ "${code}" != "200" ]; then
+            echo "slack-notify: webhook returned HTTP ${code} (non-fatal; continuing)."
+          fi
+          exit 0
+        fi
+
+        echo "slack-notify: neither bot_token nor webhook configured; skipping."

--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -4,6 +4,12 @@ description: >
   no-op when `webhook` is empty, so the workflow runs unchanged in forks and
   before the secret is configured. Never fails the job: a Slack outage must not
   turn a spec-sync run red.
+
+  Renders a single mrkdwn section — put any links inline in `text` with Slack's
+  `<url|label>` syntax. Deliberately no buttons: an `actions`/`button` block is
+  an interactive component that requires the app to configure an Interactivity
+  Request URL, which a webhook-only app has not — Slack would warn "not
+  configured to handle interactive responses" on click. Inline links don't.
 inputs:
   webhook:
     description: Slack incoming webhook URL. Empty -> silent no-op.
@@ -16,16 +22,8 @@ inputs:
     description: Bold first line of the message.
     required: true
   text:
-    description: Message body (Slack mrkdwn).
+    description: Message body (Slack mrkdwn; use <url|label> for links).
     required: true
-  link_url:
-    description: Optional button URL (e.g. the PR or the workflow run).
-    required: false
-    default: ''
-  link_text:
-    description: Button label (used only when link_url is set).
-    required: false
-    default: 'Open'
 runs:
   using: composite
   steps:
@@ -35,8 +33,6 @@ runs:
         STATUS: ${{ inputs.status }}
         TITLE: ${{ inputs.title }}
         TEXT: ${{ inputs.text }}
-        LINK_URL: ${{ inputs.link_url }}
-        LINK_TEXT: ${{ inputs.link_text }}
       run: |
         set -euo pipefail
         if [ -z "${WEBHOOK}" ]; then
@@ -49,24 +45,15 @@ runs:
           failure) emoji="🔴" ;;
           *)       emoji="ℹ️" ;;
         esac
-        # jq builds (and escapes) the Block Kit payload; the button block is only added when a URL
-        # is provided. jq is preinstalled on GitHub-hosted runners.
+        # jq builds (and escapes) the Block Kit payload. jq is preinstalled on GitHub-hosted runners.
         payload="$(jq -n \
           --arg header "${emoji} ${TITLE}" \
-          --arg text "${TEXT}" \
-          --arg url "${LINK_URL}" \
-          --arg label "${LINK_TEXT}" '
+          --arg text "${TEXT}" '
           {
-            blocks: (
-              [ { type: "section",
-                  text: { type: "mrkdwn", text: ("*" + $header + "*\n" + $text) } } ]
-              + ( if $url != "" then
-                    [ { type: "actions",
-                        elements: [ { type: "button",
-                                      text: { type: "plain_text", text: $label },
-                                      url: $url } ] } ]
-                  else [] end )
-            )
+            blocks: [
+              { type: "section",
+                text: { type: "mrkdwn", text: ("*" + $header + "*\n" + $text) } }
+            ]
           }')"
         # Non-fatal by design: capture the HTTP status, never propagate a send failure.
         code="$(curl -sS -o /dev/null -w '%{http_code}' \

--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -46,13 +46,19 @@ runs:
           *)       emoji="ℹ️" ;;
         esac
         # jq builds (and escapes) the Block Kit payload. jq is preinstalled on GitHub-hosted runners.
+        # GITHUB_REPOSITORY is a default env var the runner sets in every step (incl. composite
+        # actions), so the context footer names the source repo — ade-typescript vs ade-python — with
+        # no input to thread through and no per-repo config.
         payload="$(jq -n \
           --arg header "${emoji} ${TITLE}" \
-          --arg text "${TEXT}" '
+          --arg text "${TEXT}" \
+          --arg repo "${GITHUB_REPOSITORY}" '
           {
             blocks: [
               { type: "section",
-                text: { type: "mrkdwn", text: ("*" + $header + "*\n" + $text) } }
+                text: { type: "mrkdwn", text: ("*" + $header + "*\n" + $text) } },
+              { type: "context",
+                elements: [ { type: "mrkdwn", text: ("📦 `" + $repo + "` · spec-sync") } ] }
             ]
           }')"
         # Non-fatal by design: capture the HTTP status, never propagate a send failure.

--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -1,0 +1,77 @@
+name: Slack notify
+description: >
+  Post a spec-sync status message to Slack via an incoming webhook. A silent
+  no-op when `webhook` is empty, so the workflow runs unchanged in forks and
+  before the secret is configured. Never fails the job: a Slack outage must not
+  turn a spec-sync run red.
+inputs:
+  webhook:
+    description: Slack incoming webhook URL. Empty -> silent no-op.
+    required: false
+    default: ''
+  status:
+    description: success | warning | failure | info (drives the emoji only).
+    required: true
+  title:
+    description: Bold first line of the message.
+    required: true
+  text:
+    description: Message body (Slack mrkdwn).
+    required: true
+  link_url:
+    description: Optional button URL (e.g. the PR or the workflow run).
+    required: false
+    default: ''
+  link_text:
+    description: Button label (used only when link_url is set).
+    required: false
+    default: 'Open'
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        WEBHOOK: ${{ inputs.webhook }}
+        STATUS: ${{ inputs.status }}
+        TITLE: ${{ inputs.title }}
+        TEXT: ${{ inputs.text }}
+        LINK_URL: ${{ inputs.link_url }}
+        LINK_TEXT: ${{ inputs.link_text }}
+      run: |
+        set -euo pipefail
+        if [ -z "${WEBHOOK}" ]; then
+          echo "slack-notify: no webhook configured; skipping."
+          exit 0
+        fi
+        case "${STATUS}" in
+          success) emoji="✅" ;;
+          warning) emoji="⚠️" ;;
+          failure) emoji="🔴" ;;
+          *)       emoji="ℹ️" ;;
+        esac
+        # jq builds (and escapes) the Block Kit payload; the button block is only added when a URL
+        # is provided. jq is preinstalled on GitHub-hosted runners.
+        payload="$(jq -n \
+          --arg header "${emoji} ${TITLE}" \
+          --arg text "${TEXT}" \
+          --arg url "${LINK_URL}" \
+          --arg label "${LINK_TEXT}" '
+          {
+            blocks: (
+              [ { type: "section",
+                  text: { type: "mrkdwn", text: ("*" + $header + "*\n" + $text) } } ]
+              + ( if $url != "" then
+                    [ { type: "actions",
+                        elements: [ { type: "button",
+                                      text: { type: "plain_text", text: $label },
+                                      url: $url } ] } ]
+                  else [] end )
+            )
+          }')"
+        # Non-fatal by design: capture the HTTP status, never propagate a send failure.
+        code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          -X POST -H 'Content-type: application/json' \
+          --data "${payload}" "${WEBHOOK}" || echo "000")"
+        if [ "${code}" != "200" ]; then
+          echo "slack-notify: webhook returned HTTP ${code} (non-fatal; continuing)."
+        fi

--- a/.github/workflows/spec-sync-lifecycle.yml
+++ b/.github/workflows/spec-sync-lifecycle.yml
@@ -1,0 +1,109 @@
+name: Spec Sync Lifecycle
+# Phase 2 spec-sync Slack notifications: gate failures, merges, and aging — all posted as replies
+# under the PR-opened thread root (root ts persisted on the PR body by the spec-sync workflow).
+# These triggers run the DEFAULT-branch version of this file, so they only take effect once merged.
+on:
+  workflow_run:
+    workflows: ['PR Gates']
+    types: [completed]
+  pull_request:
+    types: [closed]
+    branches: [main]
+  schedule:
+    - cron: '0 16 * * *' # daily aging sweep
+
+permissions:
+  contents: read
+  pull-requests: write # aging writes a dedup marker to the PR body; the others only read
+
+jobs:
+  # ⑤ Gates failed on a sync PR — reply under its thread.
+  gate-alert:
+    if: >-
+      github.event_name == 'workflow_run'
+      && github.repository == 'landing-ai/ade-typescript'
+      && github.event.workflow_run.conclusion == 'failure'
+      && startsWith(github.event.workflow_run.head_branch, 'spec-sync/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Resolve sync PR + thread root
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          num="$(gh pr list --state open --head "$HEAD_BRANCH" --json number --jq '.[0].number')"
+          if [ -z "$num" ]; then echo "No open PR for $HEAD_BRANCH."; echo "found=false" >> "$GITHUB_OUTPUT"; exit 0; fi
+          {
+            echo "found=true"
+            echo "url=$(gh pr view "$num" --json url --jq .url)"
+            echo "ts=$(./scripts/spec-sync/thread-ts.sh get "$num")"
+            echo "label=$([ "$HEAD_BRANCH" = 'spec-sync/v2' ] && echo V2 || echo V1)"
+          } >> "$GITHUB_OUTPUT"
+      - name: Slack — gates failed on the sync PR
+        if: steps.pr.outputs.found == 'true'
+        uses: ./.github/actions/slack-notify
+        with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          status: failure
+          title: 'spec-sync ${{ steps.pr.outputs.label }}: gates failed on the sync PR'
+          text: 'PR Gates failed on the <${{ steps.pr.outputs.url }}|open sync PR> — it can''t merge until they are green. See <${{ github.event.workflow_run.html_url }}|the gate run>.'
+          thread_ts: ${{ steps.pr.outputs.ts }}
+
+  # ⑦ Sync PR merged — reply under its thread and broadcast to the channel.
+  merged:
+    if: >-
+      github.event_name == 'pull_request'
+      && github.repository == 'landing-ai/ade-typescript'
+      && github.event.pull_request.merged == true
+      && startsWith(github.event.pull_request.head.ref, 'spec-sync/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Read thread root
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          {
+            echo "ts=$(./scripts/spec-sync/thread-ts.sh get "$PR")"
+            echo "label=$([ "$HEAD_REF" = 'spec-sync/v2' ] && echo V2 || echo V1)"
+          } >> "$GITHUB_OUTPUT"
+      - name: Slack — sync PR merged
+        uses: ./.github/actions/slack-notify
+        with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          status: success
+          title: 'spec-sync ${{ steps.pr.outputs.label }}: PR merged — spec back in sync'
+          text: 'The <${{ github.event.pull_request.html_url }}|sync PR> was merged. Spec is back in sync.'
+          thread_ts: ${{ steps.pr.outputs.ts }}
+          reply_broadcast: 'true'
+
+  # ⑥ Aging nudge — daily reminder for a sync PR left open too long.
+  aging:
+    if: github.event_name == 'schedule' && github.repository == 'landing-ai/ade-typescript'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: [spec-sync/v1, spec-sync/v2]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check aging
+        id: age
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/spec-sync/aging-nudge.sh '${{ matrix.branch }}'
+      - name: Slack — sync PR is aging
+        if: steps.age.outputs.nudge == 'true'
+        uses: ./.github/actions/slack-notify
+        with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          status: warning
+          title: "spec-sync ${{ matrix.branch == 'spec-sync/v2' && 'V2' || 'V1' }}: sync PR open ${{ steps.age.outputs.age_days }} days"
+          text: 'The <${{ steps.age.outputs.pr_url }}|sync PR> has been open ${{ steps.age.outputs.age_days }} days. Review and merge or close it — further drift is held until it clears.'
+          thread_ts: ${{ steps.age.outputs.thread_ts }}

--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -29,6 +29,7 @@ jobs:
     env:
       V1_SPEC_URL: https://api.va.staging.landing.ai/v1/ade/openapi.json # staging drives the loop
       SYNC_BRANCH: spec-sync/v1 # fixed branch: reruns update one PR in place, never a pile of them
+      SPEC_LABEL: V1 # used only in Slack/PR-comment copy to disambiguate the two jobs
     steps:
       - uses: actions/checkout@v6
         with:
@@ -79,9 +80,26 @@ jobs:
             echo "open=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Sync PR already open — skip
+      # A sync PR is already open. Every hourly tick still reports drift (check-drift compares against
+      # main, not the PR branch), so instead of a bare skip: detect drift that appeared BEYOND the
+      # open PR and, if any, annotate the PR + emit one Slack ping per distinct new spec (deduped).
+      - name: New drift behind the open PR
+        id: behind
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open == 'true'
-        run: echo "A spec-sync PR is already open; skipping until it is merged or closed."
+        env:
+          GH_TOKEN: ${{ secrets.SPEC_SYNC_TOKEN }}
+        run: ./scripts/spec-sync/notify-new-drift.sh specs/v1-ade.json "$SYNC_BRANCH" "$SPEC_LABEL"
+
+      - name: Slack — new drift behind the open PR
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open == 'true' && steps.behind.outputs.notify == 'true'
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
+          status: warning
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: new drift behind the open PR'
+          text: 'New ${{ env.SPEC_LABEL }} spec drift appeared beyond the open sync PR (live-spec `${{ steps.behind.outputs.hash }}`). Merge or close that PR and the next run opens a fresh one covering the rest.'
+          link_url: ${{ steps.behind.outputs.pr_url }}
+          link_text: 'View PR'
 
       # ---- Phase 1: mechanical (deterministic) ----
       - name: Mechanical commit + push
@@ -98,17 +116,20 @@ jobs:
       # Open the PR now — before the AI step — so a run that dies in phase 2 leaves a visible PR
       # (with just the mechanical commit) instead of an orphan branch.
       - name: Open sync PR
+        id: open_pr
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         env:
           GH_TOKEN: ${{ secrets.SPEC_SYNC_TOKEN }}
         run: |
-          gh pr create --base main --head "$SYNC_BRANCH" \
+          url="$(gh pr create --base main --head "$SYNC_BRANCH" \
             --title "spec-sync: track V1 spec drift" \
-            --body $'Automated spec-sync PR.\n\n- **Commit 1 (mechanical):** normalized spec snapshot + regenerated reference types.\n- **Commit 2 (AI):** resources/methods/tests/docs wired from the spec diff (added after this PR opened).\n\nGates (surface-lock, contract tests, lint/build/test) must pass. **Human review required before merge.**'
+            --body $'Automated spec-sync PR.\n\n- **Commit 1 (mechanical):** normalized spec snapshot + regenerated reference types.\n- **Commit 2 (AI):** resources/methods/tests/docs wired from the spec diff (added after this PR opened).\n\nGates (surface-lock, contract tests, lint/build/test) must pass. **Human review required before merge.**')"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
 
       # ---- Phase 2: AI wiring — edits ONLY. The agent holds no shell/git-push capability, so a
       # prompt-injected spec description cannot route around review to push to a branch. ----
       - name: AI wiring (edits only)
+        id: ai_wiring
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         uses: anthropics/claude-code-action@v1
         with:
@@ -170,15 +191,50 @@ jobs:
       # Deterministic: commit whatever the AI edited (plus the refreshed report) and push. This is
       # the only step with push capability (the action's automation mode does not push).
       - name: Commit + push AI wiring
+        id: ai_push
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         run: |
           git add -A
           if git diff --cached --quiet; then
             echo "AI step produced no changes."
+            echo "summary=Mechanical-only PR (AI wiring added no changes). Human review required before merge." >> "$GITHUB_OUTPUT"
           else
             git commit -m "feat(spec-sync): wire SDK to spec diff (AI)"
             git push origin HEAD:"$SYNC_BRANCH"
+            echo "summary=Mechanical snapshot + AI wiring committed. Gates must pass; human review required before merge." >> "$GITHUB_OUTPUT"
           fi
+
+      # Case 1: fresh drift -> a new PR was opened above. Announce it once, noting whether AI wiring
+      # landed a second commit or the PR is mechanical-only.
+      - name: Slack — new drift, PR opened
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
+          status: info
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: new spec drift → PR opened'
+          text: ${{ steps.ai_push.outputs.summary }}
+          link_url: ${{ steps.open_pr.outputs.url }}
+          link_text: 'Review PR'
+
+      # Catch-all failure alert for this job. Tailors the message to the two failure modes worth
+      # calling out — a spec fetch/normalize error (often the staging cluster being unbooked) and an
+      # AI-wiring crash (PR left mechanical-only) — and falls back to a generic run-failed otherwise.
+      - name: Slack — spec-sync failed
+        if: failure()
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
+          status: failure
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: run failed'
+          text: >-
+            ${{ (steps.drift.outputs.code != '' && steps.drift.outputs.code != '0' && steps.drift.outputs.code != '10')
+            && format('Spec fetch/normalize failed (exit {0}). This targets staging — check whether the ADE cluster is unbooked (book via finops book-ade.yml) before assuming a real outage.', steps.drift.outputs.code)
+            || (steps.ai_wiring.outcome == 'failure'
+            && 'AI wiring step failed. Any open sync PR has only the mechanical commit and needs manual wiring.'
+            || 'spec-sync run failed. See the workflow run for details.') }}
+          link_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          link_text: 'View run'
 
   # V2 loop. Same machinery as the V1 job above, pointed at the V2 spec on the AIDE gateway and a
   # separate sync branch, with a V2-tailored wiring prompt. Kept a distinct job (not a matrix) so the
@@ -194,6 +250,7 @@ jobs:
     env:
       V2_SPEC_URL: https://aide.staging.landing.ai/openapi.json # staging drives the loop
       SYNC_BRANCH: spec-sync/v2 # separate branch so V1 and V2 sync PRs never collide
+      SPEC_LABEL: V2 # used only in Slack/PR-comment copy to disambiguate the two jobs
     steps:
       - uses: actions/checkout@v6
         with:
@@ -242,9 +299,26 @@ jobs:
             echo "open=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Sync PR already open — skip
+      # A sync PR is already open. Every hourly tick still reports drift (check-drift compares against
+      # main, not the PR branch), so instead of a bare skip: detect drift that appeared BEYOND the
+      # open PR and, if any, annotate the PR + emit one Slack ping per distinct new spec (deduped).
+      - name: New drift behind the open PR
+        id: behind
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open == 'true'
-        run: echo "A spec-sync PR is already open; skipping until it is merged or closed."
+        env:
+          GH_TOKEN: ${{ secrets.SPEC_SYNC_TOKEN }}
+        run: ./scripts/spec-sync/notify-new-drift.sh specs/v2-aide.json "$SYNC_BRANCH" "$SPEC_LABEL"
+
+      - name: Slack — new drift behind the open PR
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open == 'true' && steps.behind.outputs.notify == 'true'
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
+          status: warning
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: new drift behind the open PR'
+          text: 'New ${{ env.SPEC_LABEL }} spec drift appeared beyond the open sync PR (live-spec `${{ steps.behind.outputs.hash }}`). Merge or close that PR and the next run opens a fresh one covering the rest.'
+          link_url: ${{ steps.behind.outputs.pr_url }}
+          link_text: 'View PR'
 
       # ---- Phase 1: mechanical (deterministic) ----
       - name: Mechanical commit + push
@@ -259,16 +333,19 @@ jobs:
           git push --force origin "$SYNC_BRANCH"
 
       - name: Open sync PR
+        id: open_pr
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         env:
           GH_TOKEN: ${{ secrets.SPEC_SYNC_TOKEN }}
         run: |
-          gh pr create --base main --head "$SYNC_BRANCH" \
+          url="$(gh pr create --base main --head "$SYNC_BRANCH" \
             --title "spec-sync: track V2 spec drift" \
-            --body $'Automated V2 spec-sync PR (`client.v2`).\n\n- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference types.\n- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff. The shipped-but-hand-maintained `/v2/workflow*` surface is not auto-wired, so workflow-only drift lands as a **mechanical-only PR** for a maintainer to reconcile by hand.\n\nGates (surface-lock, V2 contract tests, lint/build/test) must pass. The V2 ergonomic layer (unified Job, dual-host, schema coercion) is not in the spec, so when present the AI commit is a **draft a human finishes**. **Human review required before merge.**'
+            --body $'Automated V2 spec-sync PR (`client.v2`).\n\n- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference types.\n- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff. The shipped-but-hand-maintained `/v2/workflow*` surface is not auto-wired, so workflow-only drift lands as a **mechanical-only PR** for a maintainer to reconcile by hand.\n\nGates (surface-lock, V2 contract tests, lint/build/test) must pass. The V2 ergonomic layer (unified Job, dual-host, schema coercion) is not in the spec, so when present the AI commit is a **draft a human finishes**. **Human review required before merge.**')"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
 
       # ---- Phase 2: AI wiring — edits ONLY (no shell/git-push; a later step commits). ----
       - name: AI wiring (edits only)
+        id: ai_wiring
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         uses: anthropics/claude-code-action@v1
         with:
@@ -336,12 +413,47 @@ jobs:
           yarn api-extractor
 
       - name: Commit + push AI wiring
+        id: ai_push
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         run: |
           git add -A
           if git diff --cached --quiet; then
             echo "AI step produced no changes."
+            echo "summary=Mechanical-only PR (AI wiring added no changes — e.g. workflow-only drift). Human review required before merge." >> "$GITHUB_OUTPUT"
           else
             git commit -m "feat(spec-sync): wire client.v2 to spec diff (AI)"
             git push origin HEAD:"$SYNC_BRANCH"
+            echo "summary=Mechanical snapshot + AI wiring committed (a draft a human finishes). Gates must pass; human review required before merge." >> "$GITHUB_OUTPUT"
           fi
+
+      # Case 1: fresh drift -> a new PR was opened above. Announce it once, noting whether AI wiring
+      # landed a second commit or the PR is mechanical-only.
+      - name: Slack — new drift, PR opened
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
+          status: info
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: new spec drift → PR opened'
+          text: ${{ steps.ai_push.outputs.summary }}
+          link_url: ${{ steps.open_pr.outputs.url }}
+          link_text: 'Review PR'
+
+      # Catch-all failure alert for this job. Tailors the message to the two failure modes worth
+      # calling out — a spec fetch/normalize error (often the staging cluster being unbooked) and an
+      # AI-wiring crash (PR left mechanical-only) — and falls back to a generic run-failed otherwise.
+      - name: Slack — spec-sync failed
+        if: failure()
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
+          status: failure
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: run failed'
+          text: >-
+            ${{ (steps.drift.outputs.code != '' && steps.drift.outputs.code != '0' && steps.drift.outputs.code != '10')
+            && format('Spec fetch/normalize failed (exit {0}). This targets staging — check whether the ADE cluster is unbooked (book via finops book-ade.yml) before assuming a real outage.', steps.drift.outputs.code)
+            || (steps.ai_wiring.outcome == 'failure'
+            && 'AI wiring step failed. Any open sync PR has only the mechanical commit and needs manual wiring.'
+            || 'spec-sync run failed. See the workflow run for details.') }}
+          link_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          link_text: 'View run'

--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -94,10 +94,12 @@ jobs:
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open == 'true' && steps.behind.outputs.notify == 'true'
         uses: ./.github/actions/slack-notify
         with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
           status: warning
           title: 'spec-sync ${{ env.SPEC_LABEL }}: new drift behind the open PR'
           text: 'New ${{ env.SPEC_LABEL }} spec drift appeared beyond the <${{ steps.behind.outputs.pr_url }}|open sync PR> (live-spec `${{ steps.behind.outputs.hash }}`). Merge or close it and the next run opens a fresh one covering the rest.'
+          thread_ts: ${{ steps.behind.outputs.thread_ts }}
 
       # ---- Phase 1: mechanical (deterministic) ----
       - name: Mechanical commit + push
@@ -123,6 +125,27 @@ jobs:
             --title "spec-sync: track V1 spec drift" \
             --body $'Automated spec-sync PR.\n\n- **Commit 1 (mechanical):** normalized spec snapshot + regenerated reference types.\n- **Commit 2 (AI):** resources/methods/tests/docs wired from the spec diff (added after this PR opened).\n\nGates (surface-lock, contract tests, lint/build/test) must pass. **Human review required before merge.**')"
           echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      # Post the Slack thread ROOT now — right after the PR exists, before AI wiring — so every later
+      # event (AI outcome, new drift, gates, merge) replies under it. Persist its ts on the PR body
+      # so other runs/workflows can find the thread. (Editing the body doesn't re-trigger pr-gates,
+      # which only fires on opened/synchronize/reopened.)
+      - name: Slack — PR opened (thread root)
+        id: root
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
+        uses: ./.github/actions/slack-notify
+        with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
+          status: info
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: new spec drift → PR opened'
+          text: '<${{ steps.open_pr.outputs.url }}|Open the PR> — mechanical spec snapshot committed; wiring the SDK next. Human review required before merge.'
+
+      - name: Save thread root on the PR
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true' && steps.root.outputs.ts != ''
+        env:
+          GH_TOKEN: ${{ secrets.SPEC_SYNC_TOKEN }}
+        run: ./scripts/spec-sync/thread-ts.sh set "${{ steps.open_pr.outputs.url }}" "${{ steps.root.outputs.ts }}"
 
       # ---- Phase 2: AI wiring — edits ONLY. The agent holds no shell/git-push capability, so a
       # prompt-injected spec description cannot route around review to push to a branch. ----
@@ -202,16 +225,17 @@ jobs:
             echo "summary=Mechanical snapshot + AI wiring committed. Gates must pass; human review required before merge." >> "$GITHUB_OUTPUT"
           fi
 
-      # Case 1: fresh drift -> a new PR was opened above. Announce it once, noting whether AI wiring
-      # landed a second commit or the PR is mechanical-only.
-      - name: Slack — new drift, PR opened
+      # The AI-wiring outcome, as a reply under the PR-opened thread root (steps.root).
+      - name: Slack — AI wiring result
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         uses: ./.github/actions/slack-notify
         with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
           status: info
-          title: 'spec-sync ${{ env.SPEC_LABEL }}: new spec drift → PR opened'
-          text: '<${{ steps.open_pr.outputs.url }}|Open the PR> — ${{ steps.ai_push.outputs.summary }}'
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: AI wiring'
+          text: ${{ steps.ai_push.outputs.summary }}
+          thread_ts: ${{ steps.root.outputs.ts }}
 
       # Catch-all failure alert for this job. Tailors the message to the two failure modes worth
       # calling out — a spec fetch/normalize error (often the staging cluster being unbooked) and an
@@ -220,6 +244,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/slack-notify
         with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
           status: failure
           title: 'spec-sync ${{ env.SPEC_LABEL }}: run failed'
@@ -230,6 +255,7 @@ jobs:
             && 'AI wiring step failed. Any open sync PR has only the mechanical commit and needs manual wiring.'
             || 'spec-sync run failed. See the workflow run for details.') }}
             · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
+          thread_ts: ${{ steps.root.outputs.ts }}
 
   # V2 loop. Same machinery as the V1 job above, pointed at the V2 spec on the AIDE gateway and a
   # separate sync branch, with a V2-tailored wiring prompt. Kept a distinct job (not a matrix) so the
@@ -308,10 +334,12 @@ jobs:
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open == 'true' && steps.behind.outputs.notify == 'true'
         uses: ./.github/actions/slack-notify
         with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
           status: warning
           title: 'spec-sync ${{ env.SPEC_LABEL }}: new drift behind the open PR'
           text: 'New ${{ env.SPEC_LABEL }} spec drift appeared beyond the <${{ steps.behind.outputs.pr_url }}|open sync PR> (live-spec `${{ steps.behind.outputs.hash }}`). Merge or close it and the next run opens a fresh one covering the rest.'
+          thread_ts: ${{ steps.behind.outputs.thread_ts }}
 
       # ---- Phase 1: mechanical (deterministic) ----
       - name: Mechanical commit + push
@@ -335,6 +363,27 @@ jobs:
             --title "spec-sync: track V2 spec drift" \
             --body $'Automated V2 spec-sync PR (`client.v2`).\n\n- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference types.\n- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff. The shipped-but-hand-maintained `/v2/workflow*` surface is not auto-wired, so workflow-only drift lands as a **mechanical-only PR** for a maintainer to reconcile by hand.\n\nGates (surface-lock, V2 contract tests, lint/build/test) must pass. The V2 ergonomic layer (unified Job, dual-host, schema coercion) is not in the spec, so when present the AI commit is a **draft a human finishes**. **Human review required before merge.**')"
           echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      # Post the Slack thread ROOT now — right after the PR exists, before AI wiring — so every later
+      # event (AI outcome, new drift, gates, merge) replies under it. Persist its ts on the PR body
+      # so other runs/workflows can find the thread. (Editing the body doesn't re-trigger pr-gates,
+      # which only fires on opened/synchronize/reopened.)
+      - name: Slack — PR opened (thread root)
+        id: root
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
+        uses: ./.github/actions/slack-notify
+        with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
+          status: info
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: new spec drift → PR opened'
+          text: '<${{ steps.open_pr.outputs.url }}|Open the PR> — mechanical spec snapshot committed; wiring the SDK next. Human review required before merge.'
+
+      - name: Save thread root on the PR
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true' && steps.root.outputs.ts != ''
+        env:
+          GH_TOKEN: ${{ secrets.SPEC_SYNC_TOKEN }}
+        run: ./scripts/spec-sync/thread-ts.sh set "${{ steps.open_pr.outputs.url }}" "${{ steps.root.outputs.ts }}"
 
       # ---- Phase 2: AI wiring — edits ONLY (no shell/git-push; a later step commits). ----
       - name: AI wiring (edits only)
@@ -419,16 +468,17 @@ jobs:
             echo "summary=Mechanical snapshot + AI wiring committed (a draft a human finishes). Gates must pass; human review required before merge." >> "$GITHUB_OUTPUT"
           fi
 
-      # Case 1: fresh drift -> a new PR was opened above. Announce it once, noting whether AI wiring
-      # landed a second commit or the PR is mechanical-only.
-      - name: Slack — new drift, PR opened
+      # The AI-wiring outcome, as a reply under the PR-opened thread root (steps.root).
+      - name: Slack — AI wiring result
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         uses: ./.github/actions/slack-notify
         with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
           status: info
-          title: 'spec-sync ${{ env.SPEC_LABEL }}: new spec drift → PR opened'
-          text: '<${{ steps.open_pr.outputs.url }}|Open the PR> — ${{ steps.ai_push.outputs.summary }}'
+          title: 'spec-sync ${{ env.SPEC_LABEL }}: AI wiring'
+          text: ${{ steps.ai_push.outputs.summary }}
+          thread_ts: ${{ steps.root.outputs.ts }}
 
       # Catch-all failure alert for this job. Tailors the message to the two failure modes worth
       # calling out — a spec fetch/normalize error (often the staging cluster being unbooked) and an
@@ -437,6 +487,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/slack-notify
         with:
+          bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
           status: failure
           title: 'spec-sync ${{ env.SPEC_LABEL }}: run failed'
@@ -447,3 +498,4 @@ jobs:
             && 'AI wiring step failed. Any open sync PR has only the mechanical commit and needs manual wiring.'
             || 'spec-sync run failed. See the workflow run for details.') }}
             · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
+          thread_ts: ${{ steps.root.outputs.ts }}

--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -98,8 +98,6 @@ jobs:
           status: warning
           title: 'spec-sync ${{ env.SPEC_LABEL }}: new drift behind the open PR'
           text: 'New ${{ env.SPEC_LABEL }} spec drift appeared beyond the <${{ steps.behind.outputs.pr_url }}|open sync PR> (live-spec `${{ steps.behind.outputs.hash }}`). Merge or close it and the next run opens a fresh one covering the rest.'
-          link_url: ${{ steps.behind.outputs.pr_url }}
-          link_text: 'View PR'
 
       # ---- Phase 1: mechanical (deterministic) ----
       - name: Mechanical commit + push
@@ -214,8 +212,6 @@ jobs:
           status: info
           title: 'spec-sync ${{ env.SPEC_LABEL }}: new spec drift → PR opened'
           text: '<${{ steps.open_pr.outputs.url }}|Open the PR> — ${{ steps.ai_push.outputs.summary }}'
-          link_url: ${{ steps.open_pr.outputs.url }}
-          link_text: 'Review PR'
 
       # Catch-all failure alert for this job. Tailors the message to the two failure modes worth
       # calling out — a spec fetch/normalize error (often the staging cluster being unbooked) and an
@@ -233,8 +229,7 @@ jobs:
             || (steps.ai_wiring.outcome == 'failure'
             && 'AI wiring step failed. Any open sync PR has only the mechanical commit and needs manual wiring.'
             || 'spec-sync run failed. See the workflow run for details.') }}
-          link_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          link_text: 'View run'
+            · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
 
   # V2 loop. Same machinery as the V1 job above, pointed at the V2 spec on the AIDE gateway and a
   # separate sync branch, with a V2-tailored wiring prompt. Kept a distinct job (not a matrix) so the
@@ -317,8 +312,6 @@ jobs:
           status: warning
           title: 'spec-sync ${{ env.SPEC_LABEL }}: new drift behind the open PR'
           text: 'New ${{ env.SPEC_LABEL }} spec drift appeared beyond the <${{ steps.behind.outputs.pr_url }}|open sync PR> (live-spec `${{ steps.behind.outputs.hash }}`). Merge or close it and the next run opens a fresh one covering the rest.'
-          link_url: ${{ steps.behind.outputs.pr_url }}
-          link_text: 'View PR'
 
       # ---- Phase 1: mechanical (deterministic) ----
       - name: Mechanical commit + push
@@ -436,8 +429,6 @@ jobs:
           status: info
           title: 'spec-sync ${{ env.SPEC_LABEL }}: new spec drift → PR opened'
           text: '<${{ steps.open_pr.outputs.url }}|Open the PR> — ${{ steps.ai_push.outputs.summary }}'
-          link_url: ${{ steps.open_pr.outputs.url }}
-          link_text: 'Review PR'
 
       # Catch-all failure alert for this job. Tailors the message to the two failure modes worth
       # calling out — a spec fetch/normalize error (often the staging cluster being unbooked) and an
@@ -455,5 +446,4 @@ jobs:
             || (steps.ai_wiring.outcome == 'failure'
             && 'AI wiring step failed. Any open sync PR has only the mechanical commit and needs manual wiring.'
             || 'spec-sync run failed. See the workflow run for details.') }}
-          link_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          link_text: 'View run'
+            · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>

--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -97,7 +97,7 @@ jobs:
           webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
           status: warning
           title: 'spec-sync ${{ env.SPEC_LABEL }}: new drift behind the open PR'
-          text: 'New ${{ env.SPEC_LABEL }} spec drift appeared beyond the open sync PR (live-spec `${{ steps.behind.outputs.hash }}`). Merge or close that PR and the next run opens a fresh one covering the rest.'
+          text: 'New ${{ env.SPEC_LABEL }} spec drift appeared beyond the <${{ steps.behind.outputs.pr_url }}|open sync PR> (live-spec `${{ steps.behind.outputs.hash }}`). Merge or close it and the next run opens a fresh one covering the rest.'
           link_url: ${{ steps.behind.outputs.pr_url }}
           link_text: 'View PR'
 
@@ -213,7 +213,7 @@ jobs:
           webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
           status: info
           title: 'spec-sync ${{ env.SPEC_LABEL }}: new spec drift → PR opened'
-          text: ${{ steps.ai_push.outputs.summary }}
+          text: '<${{ steps.open_pr.outputs.url }}|Open the PR> — ${{ steps.ai_push.outputs.summary }}'
           link_url: ${{ steps.open_pr.outputs.url }}
           link_text: 'Review PR'
 
@@ -229,7 +229,7 @@ jobs:
           title: 'spec-sync ${{ env.SPEC_LABEL }}: run failed'
           text: >-
             ${{ (steps.drift.outputs.code != '' && steps.drift.outputs.code != '0' && steps.drift.outputs.code != '10')
-            && format('Spec fetch/normalize failed (exit {0}). This targets staging — check whether the ADE cluster is unbooked (book via finops book-ade.yml) before assuming a real outage.', steps.drift.outputs.code)
+            && format('Spec fetch/normalize failed (exit {0}). This targets staging — check whether the ADE cluster is unbooked (book via <https://github.com/landing-ai/finops/actions/workflows/book-ade.yml|finops book-ade.yml>) before assuming a real outage.', steps.drift.outputs.code)
             || (steps.ai_wiring.outcome == 'failure'
             && 'AI wiring step failed. Any open sync PR has only the mechanical commit and needs manual wiring.'
             || 'spec-sync run failed. See the workflow run for details.') }}
@@ -316,7 +316,7 @@ jobs:
           webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
           status: warning
           title: 'spec-sync ${{ env.SPEC_LABEL }}: new drift behind the open PR'
-          text: 'New ${{ env.SPEC_LABEL }} spec drift appeared beyond the open sync PR (live-spec `${{ steps.behind.outputs.hash }}`). Merge or close that PR and the next run opens a fresh one covering the rest.'
+          text: 'New ${{ env.SPEC_LABEL }} spec drift appeared beyond the <${{ steps.behind.outputs.pr_url }}|open sync PR> (live-spec `${{ steps.behind.outputs.hash }}`). Merge or close it and the next run opens a fresh one covering the rest.'
           link_url: ${{ steps.behind.outputs.pr_url }}
           link_text: 'View PR'
 
@@ -435,7 +435,7 @@ jobs:
           webhook: ${{ secrets.SLACK_SPEC_SYNC_WEBHOOK }}
           status: info
           title: 'spec-sync ${{ env.SPEC_LABEL }}: new spec drift → PR opened'
-          text: ${{ steps.ai_push.outputs.summary }}
+          text: '<${{ steps.open_pr.outputs.url }}|Open the PR> — ${{ steps.ai_push.outputs.summary }}'
           link_url: ${{ steps.open_pr.outputs.url }}
           link_text: 'Review PR'
 
@@ -451,7 +451,7 @@ jobs:
           title: 'spec-sync ${{ env.SPEC_LABEL }}: run failed'
           text: >-
             ${{ (steps.drift.outputs.code != '' && steps.drift.outputs.code != '0' && steps.drift.outputs.code != '10')
-            && format('Spec fetch/normalize failed (exit {0}). This targets staging — check whether the ADE cluster is unbooked (book via finops book-ade.yml) before assuming a real outage.', steps.drift.outputs.code)
+            && format('Spec fetch/normalize failed (exit {0}). This targets staging — check whether the ADE cluster is unbooked (book via <https://github.com/landing-ai/finops/actions/workflows/book-ade.yml|finops book-ade.yml>) before assuming a real outage.', steps.drift.outputs.code)
             || (steps.ai_wiring.outcome == 'failure'
             && 'AI wiring step failed. Any open sync PR has only the mechanical commit and needs manual wiring.'
             || 'spec-sync run failed. See the workflow run for details.') }}

--- a/scripts/spec-sync/aging-nudge.sh
+++ b/scripts/spec-sync/aging-nudge.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Phase 2 ⑥ — aging nudge. For the open sync PR on <sync-branch>, decide whether to post a "still
+# open" reminder: fire only when it has been open at least MIN_AGE_DAYS and we have not nudged in the
+# last MIN_GAP_DAYS. Dedup via a hidden marker in the PR body that records the day of the last nudge,
+# so a stuck PR gets an escalating trickle (day 3, 6, 9…) rather than a daily nag.
+#
+# Usage: aging-nudge.sh <sync-branch>
+# Writes $GITHUB_OUTPUT: nudge=<true|false>; when true also pr_url, thread_ts, age_days.
+# Requires GH_TOKEN + gh, and a GNU `date` (the ubuntu runner has it).
+set -euo pipefail
+
+sync_branch="$1"
+min_age="${MIN_AGE_DAYS:-3}"
+min_gap="${MIN_GAP_DAYS:-3}"
+here="$(cd "$(dirname "$0")" && pwd)"
+out() { echo "$1" >> "$GITHUB_OUTPUT"; }
+
+pr="$(gh pr list --state open --head "$sync_branch" --json number --jq '.[0].number')"
+if [ -z "$pr" ]; then
+  echo "No open PR on $sync_branch."
+  out "nudge=false"; exit 0
+fi
+
+now_days=$(( $(date -u +%s) / 86400 ))
+created="$(gh pr view "$pr" --json createdAt --jq .createdAt)"
+created_days=$(( $(date -u -d "$created" +%s) / 86400 ))
+age=$(( now_days - created_days ))
+if [ "$age" -lt "$min_age" ]; then
+  echo "PR #$pr is $age day(s) old (< $min_age); no nudge."
+  out "nudge=false"; exit 0
+fi
+
+body="$(gh pr view "$pr" --json body -q .body)"
+marker="spec-sync-nudged:"
+last="$(printf '%s\n' "$body" | sed -n "s/.*<!-- ${marker} \\([0-9]*\\) -->.*/\\1/p" | head -n1)"
+if [ -n "$last" ] && [ "$(( now_days - last ))" -lt "$min_gap" ]; then
+  echo "PR #$pr nudged $(( now_days - last )) day(s) ago (< $min_gap); staying quiet."
+  out "nudge=false"; exit 0
+fi
+
+# Record today's nudge (preserve any other markers, e.g. the thread-ts one).
+cleaned="$(printf '%s\n' "$body" | grep -vF "<!-- ${marker}" || true)"
+printf '%s\n<!-- %s %s -->\n' "$cleaned" "$marker" "$now_days" | gh pr edit "$pr" --body-file -
+
+out "nudge=true"
+out "pr_url=$(gh pr view "$pr" --json url --jq .url)"
+out "thread_ts=$("$here/thread-ts.sh" get "$pr")"
+out "age_days=$age"

--- a/scripts/spec-sync/notify-new-drift.sh
+++ b/scripts/spec-sync/notify-new-drift.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Case 2 of spec-sync Slack notifications: drift is detected, but a sync PR is ALREADY open.
+#
+# The open-PR path runs every hour, and because check-drift compares the live spec against `main`
+# (not the PR branch), every one of those runs looks like "drift" until the PR merges. Notifying on
+# each would spam the channel hourly. This script suppresses that noise and fires only on genuinely
+# NEW drift that appeared *beyond* what the open PR already contains:
+#
+#   1. Compare the live spec (check-drift already wrote it into the working tree) against the PR
+#      branch's committed snapshot. Equal -> the PR already covers it -> stay silent.
+#   2. Otherwise there is new drift. Dedup by content hash via a sticky comment on the PR so we ping
+#      exactly once per distinct new live-spec, not once per hourly tick.
+#
+# Usage: notify-new-drift.sh <spec-path> <sync-branch> <label>
+# Writes to $GITHUB_OUTPUT: notify=<true|false>, and when notify=true also pr_url=<url> hash=<hash>.
+# Requires GH_TOKEN, GITHUB_REPOSITORY, and GITHUB_OUTPUT in the environment.
+set -euo pipefail
+
+spec_path="$1"
+sync_branch="$2"
+label="$3"
+
+out() { echo "$1" >> "$GITHUB_OUTPUT"; }
+
+# The live spec check-drift just wrote into the working tree vs the PR branch's committed snapshot.
+git fetch --quiet origin "$sync_branch"
+branch_spec="$(git show "origin/${sync_branch}:${spec_path}" 2>/dev/null || true)"
+if [ -n "$branch_spec" ] && [ "$branch_spec" = "$(cat "$spec_path")" ]; then
+  echo "Open PR already covers the current live spec; no new drift. Staying quiet."
+  out "notify=false"
+  exit 0
+fi
+
+hash="$(sha256sum "$spec_path" | cut -c1-12)"
+pr="$(gh pr list --state open --head "$sync_branch" --json number --jq '.[0].number')"
+if [ -z "$pr" ]; then
+  # The PR closed between the open-check and here; nothing to annotate.
+  out "notify=false"
+  exit 0
+fi
+
+# The sticky comment is both the user-facing signal and the dedup store: it always holds the latest
+# new-drift hash, so "does it already mention this hash" answers "have we pinged for this drift yet".
+marker="<!-- spec-sync-new-drift -->"
+comments="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" --paginate)"
+cid="$(printf '%s' "$comments" | jq -r "[.[] | select(.body | contains(\"$marker\"))][0].id // empty")"
+prev="$(printf '%s' "$comments" | jq -r "[.[] | select(.body | contains(\"$marker\"))][0].body // empty")"
+
+if printf '%s' "$prev" | grep -q "$hash"; then
+  echo "Already notified for live-spec ${hash}; staying quiet."
+  out "notify=false"
+  exit 0
+fi
+
+body="${marker}
+:warning: **New ${label} spec drift beyond this PR** (live-spec \`${hash}\`). This PR is a snapshot of earlier drift and is now stale relative to the live spec — merge or close it and the next spec-sync run will open a fresh PR covering the rest."
+
+if [ -n "$cid" ]; then
+  gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${cid}" -f body="$body" >/dev/null
+else
+  gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" -f body="$body" >/dev/null
+fi
+
+out "notify=true"
+out "pr_url=$(gh pr view "$pr" --json url --jq .url)"
+out "hash=${hash}"

--- a/scripts/spec-sync/notify-new-drift.sh
+++ b/scripts/spec-sync/notify-new-drift.sh
@@ -64,3 +64,5 @@ fi
 out "notify=true"
 out "pr_url=$(gh pr view "$pr" --json url --jq .url)"
 out "hash=${hash}"
+# The Slack thread root for this PR (empty if it predates threading) so the caller can reply in-thread.
+out "thread_ts=$("$(dirname "$0")/thread-ts.sh" get "$pr")"

--- a/scripts/spec-sync/thread-ts.sh
+++ b/scripts/spec-sync/thread-ts.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Persist / retrieve the Slack thread-root `ts` for a sync PR, stored as a hidden marker in the PR
+# body. Lifecycle events in later runs and other workflows (new drift, gates red, merged) read it
+# back to reply into the same thread instead of posting a fresh top-level message.
+#
+#   thread-ts.sh get <pr>       -> print the stored ts (empty if none)
+#   thread-ts.sh set <pr> <ts>  -> upsert the marker in the PR body
+#
+# Only the run that opens the PR writes; every later event only reads, so there is no write race
+# (and spec-sync is serialized by its concurrency group anyway). Requires GH_TOKEN + gh.
+set -euo pipefail
+
+marker="spec-sync-slack-thread:"
+cmd="${1:?usage: thread-ts.sh get|set <pr> [ts]}"
+pr="${2:?pr number required}"
+body="$(gh pr view "$pr" --json body -q .body 2>/dev/null || true)"
+
+case "$cmd" in
+  get)
+    printf '%s\n' "$body" | sed -n "s/.*<!-- ${marker} \\([^ ]*\\) -->.*/\\1/p" | head -n1
+    ;;
+  set)
+    ts="${3:?ts required}"
+    # Drop any existing marker line, then append the fresh one, and replace the PR body.
+    cleaned="$(printf '%s\n' "$body" | grep -vF "<!-- ${marker}" || true)"
+    printf '%s\n<!-- %s %s -->\n' "$cleaned" "$marker" "$ts" | gh pr edit "$pr" --body-file -
+    ;;
+  *)
+    echo "thread-ts.sh: unknown command '$cmd' (want get|set)" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Stacked on #85 (Phase 1). Adds a `Spec Sync Lifecycle` workflow posting three more events as **thread replies** under the PR-opened root:

- **⑤ gates red** — `workflow_run` on `PR Gates` failure for a `spec-sync/*` PR
- **⑦ merged** — `pull_request: closed` + merged, with `reply_broadcast`
- **⑥ aging** — daily `schedule`; nudges a sync PR open ≥3 days, deduped via a PR-body marker (day 3, 6, 9…) so it trickles rather than nags

All read the root ts via `thread-ts.sh`. These triggers run the default-branch version, so they take effect once merged. Validated: actionlint clean, aging logic mock-tested (5 paths), and a smoke run posted the root + three threaded replies (0 send failures).

Note: base is #85's branch to keep the diff Phase-2-only — retarget to `main` after #85 merges.