### PR TITLE
fix(spec-sync): address Copilot review (parity with ade-python)

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -80,24 +80,29 @@ runs:
         # Preferred: Web API. Returns the message ts (needed to thread later events) and accepts
         # thread_ts to reply under an existing root.
         if [ -n "${BOT_TOKEN}" ]; then
+          # Fallback text (notifications + screen readers) carries the body too, not just the title.
+          fallback="${emoji} ${TITLE}"
+          if [ -n "${TEXT}" ]; then fallback="${fallback}"$'\n'"${TEXT}"; fi
           payload="$(jq -n \
             --arg channel "${CHANNEL}" \
-            --arg fallback "${emoji} ${TITLE}" \
+            --arg fallback "${fallback}" \
             --argjson blocks "${blocks}" \
             --arg thread "${THREAD_TS}" \
             --arg broadcast "${REPLY_BROADCAST}" '
             { channel: $channel, text: $fallback, blocks: $blocks }
             + (if $thread != "" then { thread_ts: $thread } else {} end)
             + (if $thread != "" and $broadcast == "true" then { reply_broadcast: true } else {} end)')"
-          resp="$(curl -sS -X POST \
+          # --connect-timeout/--max-time bound a hung connection so a Slack stall can't hold the job.
+          resp="$(curl -sS --connect-timeout 10 --max-time 20 -X POST \
             -H "Authorization: Bearer ${BOT_TOKEN}" \
             -H 'Content-type: application/json; charset=utf-8' \
             --data "${payload}" https://slack.com/api/chat.postMessage \
             || echo '{"ok":false,"error":"curl_failed"}')"
-          if [ "$(printf '%s' "${resp}" | jq -r '.ok')" = "true" ]; then
-            printf 'ts=%s\n' "$(printf '%s' "${resp}" | jq -r '.ts')" >> "$GITHUB_OUTPUT"
+          # Parse defensively: an empty/non-JSON response must not fail the step (non-fatal contract).
+          if [ "$(printf '%s' "${resp}" | jq -r '.ok // false' 2>/dev/null || echo false)" = "true" ]; then
+            printf 'ts=%s\n' "$(printf '%s' "${resp}" | jq -r '.ts // empty' 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
           else
-            echo "slack-notify: chat.postMessage failed: $(printf '%s' "${resp}" | jq -r '.error // "unknown"') (non-fatal; continuing)."
+            echo "slack-notify: chat.postMessage failed: $(printf '%s' "${resp}" | jq -r '.error // "unknown"' 2>/dev/null || echo 'non-JSON response') (non-fatal; continuing)."
           fi
           exit 0
         fi
@@ -105,7 +110,7 @@ runs:
         # Fallback: incoming webhook. Flat only — returns no ts, so threading silently degrades.
         if [ -n "${WEBHOOK}" ]; then
           payload="$(jq -n --argjson blocks "${blocks}" '{ blocks: $blocks }')"
-          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          code="$(curl -sS --connect-timeout 10 --max-time 20 -o /dev/null -w '%{http_code}' \
             -X POST -H 'Content-type: application/json' \
             --data "${payload}" "${WEBHOOK}" || echo "000")"
           if [ "${code}" != "200" ]; then

--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -143,6 +143,7 @@ jobs:
 
       - name: Save thread root on the PR
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true' && steps.root.outputs.ts != ''
+        continue-on-error: true # bookkeeping only; thread-ts.sh fails closed, and a hiccup must not red the run
         env:
           GH_TOKEN: ${{ secrets.SPEC_SYNC_TOKEN }}
         run: ./scripts/spec-sync/thread-ts.sh set "${{ steps.open_pr.outputs.url }}" "${{ steps.root.outputs.ts }}"
@@ -227,7 +228,7 @@ jobs:
 
       # The AI-wiring outcome, as a reply under the PR-opened thread root (steps.root).
       - name: Slack — AI wiring result
-        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true' && steps.root.outputs.ts != ''
         uses: ./.github/actions/slack-notify
         with:
           bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -381,6 +382,7 @@ jobs:
 
       - name: Save thread root on the PR
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true' && steps.root.outputs.ts != ''
+        continue-on-error: true # bookkeeping only; thread-ts.sh fails closed, and a hiccup must not red the run
         env:
           GH_TOKEN: ${{ secrets.SPEC_SYNC_TOKEN }}
         run: ./scripts/spec-sync/thread-ts.sh set "${{ steps.open_pr.outputs.url }}" "${{ steps.root.outputs.ts }}"
@@ -470,7 +472,7 @@ jobs:
 
       # The AI-wiring outcome, as a reply under the PR-opened thread root (steps.root).
       - name: Slack — AI wiring result
-        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
+        if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true' && steps.root.outputs.ts != ''
         uses: ./.github/actions/slack-notify
         with:
           bot_token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/scripts/spec-sync/thread-ts.sh
+++ b/scripts/spec-sync/thread-ts.sh
@@ -13,14 +13,22 @@ set -euo pipefail
 marker="spec-sync-slack-thread:"
 cmd="${1:?usage: thread-ts.sh get|set <pr> [ts]}"
 pr="${2:?pr number required}"
-body="$(gh pr view "$pr" --json body -q .body 2>/dev/null || true)"
 
 case "$cmd" in
   get)
+    # Best-effort: a read failure just means "no thread root yet" -> caller posts top-level.
+    body="$(gh pr view "$pr" --json body -q .body 2>/dev/null || true)"
     printf '%s\n' "$body" | sed -n "s/.*<!-- ${marker} \\([^ ]*\\) -->.*/\\1/p" | head -n1
     ;;
   set)
     ts="${3:?ts required}"
+    # Fail closed: a `gh pr view` failure must NOT look like an empty body, or the `gh pr edit`
+    # below would replace the entire PR description with just the marker. Abort instead. (An
+    # actually-empty description is a success with empty output, and is handled fine.)
+    if ! body="$(gh pr view "$pr" --json body -q .body)"; then
+      echo "thread-ts.sh: could not read PR #$pr body; refusing to overwrite it." >&2
+      exit 1
+    fi
     # Drop any existing marker line, then append the fresh one, and replace the PR body.
     cleaned="$(printf '%s\n' "$body" | grep -vF "<!-- ${marker}" || true)"
     printf '%s\n<!-- %s %s -->\n' "$cleaned" "$marker" "$ts" | gh pr edit "$pr" --body-file -


### PR DESCRIPTION
Brings ade-typescript to parity with the Copilot-review fixes already shipped in ade-python (#118/#119). ade-typescript's #85/#86 merged before these were ported, so this is a standalone follow-up.

- **slack-notify**: bound `curl` (`--connect-timeout`/`--max-time`) so a hung Slack connection can't hold the job; parse the response defensively (empty/non-JSON can't fail the step); include the body in the top-level fallback `text` (notifications + screen readers).
- **thread-ts.sh**: `set` fails closed — abort if the PR body can't be read, instead of overwriting the description with just the marker.
- **spec-sync.yml**: gate the AI-result reply on a thread root ts (no duplicate top-level message in webhook-only mode); `save-thread-root` is `continue-on-error`.

`action.yml` and `thread-ts.sh` are byte-identical to ade-python. actionlint clean; behaviors were mock-tested when the fixes landed in ade-python. Deferred (separate follow-up, per request): the case-2 dedup A→B→A and post-confirmation hash recording.