### PR TITLE
feat(spec-sync): read specs from S3 instead of live staging

### DIFF
--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60 # headroom for the AI wiring step (up to --max-turns 250) plus install/build
     env:
-      V1_SPEC_URL: https://api.va.staging.landing.ai/v1/ade/openapi.json # staging drives the loop
+      V1_SPEC_URL: https://ade-specs.s3.us-east-2.amazonaws.com/v1/staging/openapi.json # staging spec, published to S3 by vision-tools-rest-api CI (no cluster booking needed)
       SYNC_BRANCH: spec-sync/v1 # fixed branch: reruns update one PR in place, never a pile of them
       SPEC_LABEL: V1 # used only in Slack/PR-comment copy to disambiguate the two jobs
     steps:
@@ -270,7 +270,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60 # headroom for the AI wiring step (up to --max-turns 250) plus install/build
     env:
-      V2_SPEC_URL: https://aide.staging.landing.ai/openapi.json # staging drives the loop
+      V2_SPEC_URL: https://ade-specs.s3.us-east-2.amazonaws.com/v2/staging/openapi.json # staging spec, published to S3 by aide CI (no cluster booking needed)
       SYNC_BRANCH: spec-sync/v2 # separate branch so V1 and V2 sync PRs never collide
       SPEC_LABEL: V2 # used only in Slack/PR-comment copy to disambiguate the two jobs
     steps:


### PR DESCRIPTION
Points spec-sync's `V1_SPEC_URL`/`V2_SPEC_URL` at the CI-published S3 specs:
- v1 → `https://ade-specs.s3.us-east-2.amazonaws.com/v1/staging/openapi.json` (published by vision-tools-rest-api)
- v2 → `https://ade-specs.s3.us-east-2.amazonaws.com/v2/staging/openapi.json` (published by aide)

## Why
The drift loop pulled the specs from live staging (`api.va.staging` / `aide.staging`), which is bookable and auto-closes to save cost — so the fetch 404s when staging is down. The upstream repos now generate the spec in CI (spec = f(code)) and publish it to S3, removing that dependency.

## No drift
Both S3 objects were verified **byte-identical** (after `jq -S` normalization) to what the live staging endpoints currently serve, so this swap introduces zero spurious drift. `check-drift.sh` is unchanged (still `curl | jq -S`; public HTTPS, no auth).

Pairs with vision-tools-rest-api#883 and aide#1087 (the publishers).