### PR TITLE
fix(spec-sync): unstage AI edits so the product-code allowlist actually reverts them

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,3 +33,17 @@ When performing a code review on these PRs:
 - Once the wiring commit is present, focus the review on whether the wired surface matches
   the spec diff: routes, parameter names, request/response fields, required-vs-optional,
   and sync/async (job) surface consistency.
+- Do **not** flag the prose inside the snapshot files (`specs/v2-aide.json`,
+  `specs/_generated/`) — `summary` / `description` / `title` wording and the like. Those files
+  are a verbatim mirror of the upstream OpenAPI spec (published to S3 by the API's CI) and are
+  regenerated on every sync, so they cannot be edited in this repo. Wording fixes — e.g. a
+  build-schema endpoint whose `summary` reads `"ADE Extract"`, or a build-schema jobs endpoint
+  described as an "Extract job" — must land upstream, not here.
+
+## Known-intentional SDK conventions (do not report)
+
+- `saveTo` directory-mode filenames are intentionally `{method}_output.json` when no single
+  input file or URL can be derived. Methods whose inputs are arrays or absent — e.g.
+  `client.v2.buildSchema` (`markdowns` / `markdown_urls`) and `client.v2.ground` — pass
+  `_getInputFilename(null, null)` on purpose, mirroring the shared V1/V2 helper. This is
+  deliberate and consistent; do not report it as lost input-derived naming.

--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -195,6 +195,12 @@ jobs:
       # tools — and before the `git add -A` below — enforce the product-code ALLOWLIST: revert every
       # tracked edit and delete every untracked file OUTSIDE src/ tests/ api.md README.md. This stops
       # an injected edit to e.g. a config that defines what `format`/`build` run from executing here.
+      #
+      # The action STAGES its edits (git add) but does not commit. `git checkout -- .` restores the
+      # working tree FROM THE INDEX, so a staged edit survives it — the revert must therefore unstage
+      # first (`git reset -q`) so it sees every AI edit as a working-tree change and `git clean` sees
+      # new files as untracked. Without the reset the allowlist is a no-op and non-product edits (a
+      # config, a dotfile) reach `format`/`build` and the commit below.
       # (`git clean` has no -x, so gitignored paths like node_modules/ and dist/ are untouched.)
       #
       # Then format, build, and refresh the API report so the AI's additive surface is reflected in
@@ -204,6 +210,7 @@ jobs:
       - name: Restrict AI edits to product code, then format + refresh the API report
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         run: |
+          git reset -q # unstage the action's edits so the allowlist revert + clean below actually apply
           git checkout -- . ':(exclude)src' ':(exclude)tests' ':(exclude)api.md' ':(exclude)README.md'
           git clean -fd -e /src -e /tests
           ./scripts/format
@@ -461,9 +468,13 @@ jobs:
             --max-turns 250
             --allowedTools "Edit,Write,Read,Glob,Grep,Bash(git diff:*)"
 
+      # See the V1 job's copy of this step for why: the action stages its edits, so `git checkout`
+      # (which restores from the index) is a no-op on them — unstage with `git reset -q` first so the
+      # product-code allowlist revert + clean actually apply before format/build run.
       - name: Restrict AI edits to product code, then format + refresh the API report
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         run: |
+          git reset -q # unstage the action's edits so the allowlist revert + clean below actually apply
           git checkout -- . ':(exclude)src' ':(exclude)tests' ':(exclude)api.md' ':(exclude)README.md'
           git clean -fd -e /src -e /tests
           ./scripts/format


### PR DESCRIPTION
Prevents the three classes of Copilot findings on the spec-sync/v2 drift PR (#93) from recurring.

**1. The guard didn't revert staged non-product edits (root cause of the stray `.github/` edit).**
The AI-wiring guard reverts non-product edits with `git checkout -- .`, which restores the working tree *from the index*. `claude-code-action` **stages** its edits without committing, so staged non-product changes slipped past the guard and reached `format`/`build` and the commit — defeating both the prompt-injection guard and the product-code allowlist. Fixed by unstaging (`git reset -q`) before the revert + clean, in **both** the V1 and V2 jobs.

**2 & 3. Steer Copilot away from non-actionable nits (`.github/copilot-instructions.md`).**
- Don't flag prose in the snapshot files (`summary`/`description` wording) — it's a verbatim mirror of the upstream OpenAPI spec, regenerated every sync and unfixable here; fixes belong upstream.
- Document the intentional `saveTo` → `{method}_output.json` naming for methods whose inputs are arrays/absent (`buildSchema`, `ground`).

The `.github/` markdown regression Copilot flagged on #93 self-heals: once this merges, the next spec-sync rerun regenerates that branch without the stray edit.