### PR TITLE
feat: send structured User-Agent and X-Source: sdk on every request

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,19 @@ console.log(raw.headers.get('X-My-Header'));
 console.log(data.chunks);
 ```
 
+### Client Identity Headers
+
+Every request carries two headers that let the platform attribute traffic to this SDK:
+
+- `X-Source: sdk`
+- a structured `User-Agent`, e.g. `ade-typescript/2.10.0 (MacOS arm64) node/20`
+
+You can override either one by supplying the same header via `defaultHeaders` on the client or `headers` on a request — a caller-supplied value replaces the SDK default. Leave them untouched to keep accurate attribution.
+
+```ts
+const client = new LandingAIADE({ defaultHeaders: { 'User-Agent': 'my-app/1.0' } }); // replaces the SDK User-Agent
+```
+
 ### File Uploads
 
 Request parameters that correspond to file uploads (such as `document`, `markdown`, and `file`) can be passed in several forms:

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,6 +9,7 @@ export type { Logger, LogLevel } from './internal/utils/log';
 import { castToError, isAbortError } from './internal/errors';
 import type { APIResponseProps } from './internal/parse';
 import { getPlatformHeaders } from './internal/detect-platform';
+import { SOURCE, buildUserAgent } from './internal/client-identity';
 import * as Shims from './internal/shims';
 import * as Opts from './internal/request-options';
 import { stringifyQuery } from './internal/utils/query';
@@ -607,7 +608,9 @@ export class LandingAIADE {
   }
 
   private getUserAgent(): string {
-    return `${this.constructor.name}/JS ${VERSION}`;
+    // Structured client identity (landing-ai/ade-typescript#96), built in the
+    // single seam in `internal/client-identity`. Never throws.
+    return buildUserAgent(VERSION);
   }
 
   protected defaultIdempotencyKey(): string {
@@ -1021,6 +1024,10 @@ export class LandingAIADE {
       {
         Accept: 'application/json',
         'User-Agent': this.getUserAgent(),
+        // Client identity (landing-ai/ade-typescript#96). Sits before
+        // `defaultHeaders`/per-request `headers` below, so a caller can still
+        // override the identity if it must.
+        'X-Source': SOURCE,
         'X-Stainless-Retry-Count': String(retryCount),
         ...(options.timeout ? { 'X-Stainless-Timeout': String(Math.trunc(options.timeout / 1000)) } : {}),
         runtime_tag: `ade-typescript-v${VERSION}`,

--- a/src/internal/client-identity.ts
+++ b/src/internal/client-identity.ts
@@ -37,12 +37,13 @@ const PRODUCT = 'ade-typescript';
 const PLACEHOLDER = 'unknown';
 
 /**
- * Anything that would break the parser's `(<os> <arch>)` shape — whitespace,
- * `;`/`,`, or parentheses — is collapsed into a single `-` so an exotic platform
- * never splits into extra "words".
+ * Keep only visible-ASCII token characters; collapse everything else into a
+ * single `-`. This covers what would break the parser's `(<os> <arch>)` shape
+ * (whitespace, `;`/`,`, parentheses) AND non-ASCII values, so an exotic platform
+ * string can never split into extra "words" or smuggle a non-header-safe byte in.
  */
 const cleanToken = (value: string): string =>
-  value.replace(/[\s;,()]+/g, '-').replace(/^-+|-+$/g, '') || PLACEHOLDER;
+  value.replace(/[^A-Za-z0-9._:+-]+/g, '-').replace(/^-+|-+$/g, '') || PLACEHOLDER;
 
 /**
  * Build the structured `User-Agent`. Never throws.

--- a/src/internal/client-identity.ts
+++ b/src/internal/client-identity.ts
@@ -1,0 +1,73 @@
+import { getPlatformHeaders } from './detect-platform';
+
+/**
+ * Client identity attached to every API request (see landing-ai/ade-typescript#96).
+ *
+ * The AIDE gateway relays these two headers into the recorded `inference_history`
+ * row so SDK traffic is distinguishable from raw API calls:
+ *
+ * - `X-Source: sdk` — names the row's `source` column (the coarse API/CLI/SDK
+ *   split; `sdk` is already live in the platform's `InferenceHistorySource` enum).
+ * - a structured `User-Agent` — parsed platform-side into os/arch/runtime dimensions.
+ *
+ * The User-Agent grammar is shared with ade-cli (its `docs/user-agent.md`) and
+ * parsed by vision-agent-ui's `parseUserAgent.ts`:
+ *
+ *     ade-typescript/<version> (<os> <arch>) <runtime>/<major>
+ *
+ * The parser owns the grammar, not the vocabulary: the leading token identifies
+ * the product, the parenthesized comment fills os/arch *only* when it is exactly
+ * two space-separated words with no `;`/`,`, and every remaining `key/value`
+ * token is captured generically — so appending further tokens later (e.g. an
+ * HTTP-lib token, host-app detection) needs no platform change.
+ *
+ * Nothing here throws: identity must never fail a request, so every lookup
+ * degrades to a placeholder.
+ */
+
+/** `X-Source` value: the coarse API/CLI/SDK split. */
+export const SOURCE = 'sdk';
+
+/**
+ * Leading product token. `ade-typescript` (not the package name `landingai-ade`)
+ * keeps the two SDKs separable — the Python SDK uses `ade-python`.
+ */
+const PRODUCT = 'ade-typescript';
+
+const PLACEHOLDER = 'unknown';
+
+/**
+ * Anything that would break the parser's `(<os> <arch>)` shape — whitespace,
+ * `;`/`,`, or parentheses — is collapsed into a single `-` so an exotic platform
+ * never splits into extra "words".
+ */
+const cleanToken = (value: string): string =>
+  value.replace(/[\s;,()]+/g, '-').replace(/^-+|-+$/g, '') || PLACEHOLDER;
+
+/**
+ * Build the structured `User-Agent`. Never throws.
+ *
+ * `version` is the SDK version the client already holds (`VERSION`), so the
+ * identity never depends on a runtime package.json read. os/arch/runtime come
+ * from the SDK's shared platform detection; exotic or missing values degrade to
+ * placeholders so a malformed token never ships.
+ */
+export function buildUserAgent(version: string): string {
+  let os = PLACEHOLDER;
+  let arch = PLACEHOLDER;
+  // Documented grammar leads with `node/<major>`; other runtimes report their
+  // own name (`browser:<name>` collapses to a clean single-word key).
+  let runtime = PLACEHOLDER;
+  let runtimeMajor = PLACEHOLDER;
+  try {
+    const platform = getPlatformHeaders();
+    os = cleanToken(platform['X-Stainless-OS'] || PLACEHOLDER);
+    arch = cleanToken(platform['X-Stainless-Arch'] || PLACEHOLDER);
+    runtime = cleanToken((platform['X-Stainless-Runtime'] || PLACEHOLDER).split(':')[0]!);
+    runtimeMajor = /\d+/.exec(platform['X-Stainless-Runtime-Version'] || '')?.[0] ?? PLACEHOLDER;
+  } catch {
+    // Exotic runtime with no platform detection — keep placeholders rather than
+    // fail the request over identity.
+  }
+  return `${PRODUCT}/${cleanToken(version)} (${os} ${arch}) ${runtime}/${runtimeMajor}`;
+}

--- a/tests/client-identity.test.ts
+++ b/tests/client-identity.test.ts
@@ -160,4 +160,22 @@ describe('never throws', () => {
     });
     jest.dontMock('landingai-ade/internal/detect-platform');
   });
+
+  test('non-ASCII platform values are stripped to ASCII', () => {
+    jest.isolateModules(() => {
+      jest.doMock('landingai-ade/internal/detect-platform', () => ({
+        getPlatformHeaders: () => ({
+          'X-Stainless-OS': 'Linux',
+          'X-Stainless-Arch': 'arm\u{1F525}', // arm🔥
+          'X-Stainless-Runtime': 'node',
+          'X-Stainless-Runtime-Version': 'v20.0.0',
+        }),
+      }));
+      const { buildUserAgent: build } = require('landingai-ade/internal/client-identity');
+      const ua: string = build('1.2.3');
+      expect(ua).toMatch(/^[\x20-\x7E]*$/); // printable ASCII — header-encodable
+      expect(ua).toContain('(Linux arm)'); // emoji stripped, not split into a 3rd word
+    });
+    jest.dontMock('landingai-ade/internal/detect-platform');
+  });
 });

--- a/tests/client-identity.test.ts
+++ b/tests/client-identity.test.ts
@@ -1,0 +1,163 @@
+// Client identity headers — User-Agent + X-Source (landing-ai/ade-typescript#96).
+import LandingAIADE from 'landingai-ade';
+import { SOURCE, buildUserAgent } from 'landingai-ade/internal/client-identity';
+
+const client = new LandingAIADE({ baseURL: 'http://localhost:5000/', apikey: 'My Apikey' });
+
+// Endpoints spanning the operations in the issue: parse, extract, and job
+// submit (POST .../jobs) + poll (GET .../jobs/{id}).
+const ENDPOINTS: Array<[string, 'get' | 'post']> = [
+  ['/v1/ade/parse', 'post'],
+  ['/v1/ade/extract', 'post'],
+  ['/v1/ade/parse/jobs', 'post'], // submit
+  ['/v1/ade/parse/jobs/job_123', 'get'], // poll
+  ['/v1/ade/extract/jobs', 'post'], // submit
+  ['/v1/ade/extract/jobs/job_123', 'get'], // poll
+];
+
+/**
+ * Faithful port of vision-agent-ui's `parseUserAgent.ts` (the platform parser),
+ * kept in lockstep so these tests fail if our User-Agent drifts from the shape
+ * the platform actually reads.
+ */
+function parseUserAgent(raw: string): Record<string, string> {
+  const analysis: Record<string, string> = { raw };
+
+  const comment = /\(([^)]*)\)/.exec(raw);
+  let tokens: string[];
+  if (comment) {
+    const inner = comment[1] ?? '';
+    const parts = inner.trim().split(/\s+/);
+    if (parts.length === 2 && !/[;,]/.test(inner)) {
+      analysis['os'] = parts[0]!;
+      analysis['arch'] = parts[1]!;
+    }
+    tokens = raw.replace(comment[0]!, ' ').trim().split(/\s+/);
+  } else {
+    tokens = raw.trim().split(/\s+/);
+  }
+
+  const [product, ...rest] = tokens;
+  const productMatch = /^([^/]+)\/(.+)$/.exec(product ?? '');
+  if (productMatch) {
+    analysis['product'] = productMatch[1]!;
+    analysis['productVersion'] = productMatch[2]!;
+  }
+
+  const reserved = new Set(['raw', 'product', 'productVersion', 'os', 'arch']);
+  for (const token of rest) {
+    const slash = token.indexOf('/');
+    if (slash <= 0 || slash === token.length - 1) continue;
+    const key = token.slice(0, slash);
+    if (reserved.has(key) || analysis[key] !== undefined) continue;
+    analysis[key] = token.slice(slash + 1);
+  }
+
+  return analysis;
+}
+
+describe('User-Agent grammar', () => {
+  test('parses per platform contract', () => {
+    const parsed = parseUserAgent(buildUserAgent('2.10.0'));
+    expect(parsed['product']).toBe('ade-typescript');
+    expect(parsed['productVersion']).toBe('2.10.0');
+    // The `(<os> <arch>)` comment fills both dimensions.
+    expect(parsed['os']).toBeTruthy();
+    expect(parsed['arch']).toBeTruthy();
+    // Runtime key/value token — tests run on Node, so `node/<major>` is present.
+    expect(parsed['node']).toBeTruthy();
+  });
+
+  test('platform comment shape', () => {
+    // Exactly two space-separated words, no `;`/`,` — the only shape the
+    // platform parser reads into os/arch.
+    const comment = /\(([^)]*)\)/.exec(buildUserAgent('x'));
+    expect(comment).not.toBeNull();
+    const inner = comment![1]!;
+    expect(inner).not.toMatch(/[;,]/);
+    expect(inner.trim().split(/\s+/)).toHaveLength(2);
+  });
+});
+
+describe('X-Source', () => {
+  test('is the sdk source', () => {
+    expect(SOURCE).toBe('sdk');
+  });
+});
+
+describe('every request carries identity', () => {
+  test.each(ENDPOINTS)('%s %s', async (path, method) => {
+    const { req } = await client.buildRequest({ path, method });
+    expect(req.headers.get('x-source')).toBe('sdk');
+    expect(req.headers.get('user-agent')).toMatch(/^ade-typescript\//);
+  });
+});
+
+describe('caller override', () => {
+  test('default is the sdk identity', async () => {
+    const { req } = await client.buildRequest({ path: '/v1/ade/parse', method: 'post' });
+    expect(req.headers.get('x-source')).toBe('sdk');
+    expect(req.headers.get('user-agent')).toMatch(/^ade-typescript\//);
+  });
+
+  test('a caller-supplied default header overrides (documented)', async () => {
+    const overridden = new LandingAIADE({
+      baseURL: 'http://localhost:5000/',
+      apikey: 'My Apikey',
+      defaultHeaders: { 'X-Source': 'myapp' },
+    });
+    const { req } = await overridden.buildRequest({ path: '/v1/ade/parse', method: 'post' });
+    expect(req.headers.get('x-source')).toBe('myapp');
+  });
+
+  test('a per-request header overrides (documented)', async () => {
+    const { req } = await client.buildRequest({
+      path: '/v1/ade/parse',
+      method: 'post',
+      headers: { 'X-Source': 'per-request' },
+    });
+    expect(req.headers.get('x-source')).toBe('per-request');
+  });
+});
+
+describe('never throws', () => {
+  test('version degrades to unknown', () => {
+    expect(buildUserAgent('')).toMatch(/^ade-typescript\/unknown /);
+  });
+
+  test('platform detection failure degrades', () => {
+    jest.isolateModules(() => {
+      jest.doMock('landingai-ade/internal/detect-platform', () => ({
+        getPlatformHeaders: () => {
+          throw new Error('boom');
+        },
+      }));
+      const { buildUserAgent: build } = require('landingai-ade/internal/client-identity');
+      const ua: string = build('9.9.9');
+      expect(ua.startsWith('ade-typescript/9.9.9')).toBe(true);
+      expect(ua).toContain('(unknown unknown)');
+      expect(ua).toContain('unknown/unknown');
+    });
+    jest.dontMock('landingai-ade/internal/detect-platform');
+  });
+
+  test('exotic platform values stay a valid two-word comment', () => {
+    jest.isolateModules(() => {
+      jest.doMock('landingai-ade/internal/detect-platform', () => ({
+        getPlatformHeaders: () => ({
+          'X-Stainless-OS': 'Other:weird os name', // contains spaces
+          'X-Stainless-Arch': '', // empty
+          'X-Stainless-Runtime': 'browser:chrome',
+          'X-Stainless-Runtime-Version': 'no-digits',
+        }),
+      }));
+      const { buildUserAgent: build } = require('landingai-ade/internal/client-identity');
+      const ua: string = build('1.2.3');
+      const inner = /\(([^)]*)\)/.exec(ua)![1]!;
+      expect(inner).not.toMatch(/[;,]/);
+      expect(inner.trim().split(/\s+/)).toHaveLength(2); // spaces in OS collapsed, empty arch -> unknown
+      expect(ua).toContain('browser/unknown'); // subtype collapsed, no digits -> unknown
+    });
+    jest.dontMock('landingai-ade/internal/detect-platform');
+  });
+});


### PR DESCRIPTION
Attach client identity to every SDK request so the platform can attribute traffic to the SDK.

- `internal/client-identity.buildUserAgent()` — single seam; `ade-typescript/<ver> (<os> <arch>) <runtime>/<major>` (ade-cli's grammar). Never throws; degrades exotic/missing values to placeholders.
- `X-Source: sdk` + the UA wired into `buildHeaders` → every resource (v1, v2 jobs submit + poll) carries them; caller `defaultHeaders`/per-request `headers` still override.
- Reuses the memoized `getPlatformHeaders()` and the baked-in `VERSION` (no per-request work). Module is internal, so the public API report is unchanged.

Fixes:
- Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)