### PR TITLE
spec-sync: track V2 spec drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ try {
 }
 ```
 
-The `create`, `get`, and `wait` methods return a normalized `Job` with `job_id`, `status` (`pending`, `processing`, `completed`, `failed`, or `cancelled`), `progress`, `result`, `error`, `is_terminal`, and `raw` (the unmodified API envelope, for any field not surfaced on the typed shape). The `list` method returns a `JobList` with a `jobs` array and `has_more`, plus the `page`/`page_size` pagination fields; `org_id` is populated only by older parse envelopes. Fields an endpoint doesn't populate are `null`.
+The `create`, `get`, and `wait` methods return a normalized `Job` with `job_id`, `status` (`pending`, `processing`, `completed`, `failed`, or `cancelled`), `progress`, `result`, `metadata`, `error`, `is_terminal`, and `raw` (the unmodified API envelope, for any field not surfaced on the typed shape). The `list` method returns a `JobList` with a `jobs` array and `has_more`, plus the `page`/`page_size` pagination fields; `org_id` is populated only by older parse envelopes. Fields an endpoint doesn't populate are `null`.
 
 ```ts
 // Poll manually instead of blocking
@@ -274,7 +274,25 @@ for (const j of jobs.jobs) {
 console.log(jobs.has_more);
 ```
 
-Extract jobs work the same way. The `create` method takes the same schema and Markdown arguments as `client.v2.extract`, plus `service_tier` and an optional `output_save_url` (a presigned URL the finished result is delivered to; the completed job then reports `output_url` in `Job.raw` instead of an inline `result`); it does not accept `saveTo`. Build-schema jobs mirror `client.v2.buildSchema`, taking the same `markdowns`/`markdown_urls`/`prompt`/`schema` arguments plus `service_tier`, and their `result` is a `V2BuildSchemaResult`. Ground has no async jobs surface — use the synchronous `client.v2.ground` directly.
+Extract jobs work the same way. The `create` method takes the same schema and Markdown arguments as `client.v2.extract`, plus `service_tier` and an optional `output_save_url` (a presigned URL the finished result is delivered to; the completed job then reports `output_url` in `Job.raw` instead of an inline `result`); it does not accept `saveTo`.
+
+```ts
+// A job created with `output_save_url` delivers the result out-of-band, but the
+// receipt still comes back on the job: `Job.metadata` carries the parse/extract
+// metadata (billing included) alongside `output_url` in `Job.raw`.
+const delivery = await client.v2.extractJobs.create({
+  schema: { type: 'object', properties: { revenue: { type: 'string' } } },
+  markdown: '# Acme Inc. — Q1 Report',
+  output_save_url: 'https://example.com/presigned-put-url',
+});
+const done = await client.v2.extractJobs.wait(delivery.job_id);
+if (done.result === null && done.metadata) {
+  const metadata = done.metadata as LandingAIADE.V2ExtractMetadata;
+  console.log(done.raw['output_url'], metadata.duration_ms, metadata.billing?.total_credits);
+}
+```
+
+Inline jobs leave `Job.metadata` `null` and carry their metadata inside `result` instead. Build-schema jobs mirror `client.v2.buildSchema`, taking the same `markdowns`/`markdown_urls`/`prompt`/`schema` arguments plus `service_tier`, and their `result` is a `V2BuildSchemaResult`. Ground has no async jobs surface — use the synchronous `client.v2.ground` directly.
 
 ## Environments
 

--- a/api.md
+++ b/api.md
@@ -59,6 +59,8 @@ The `client.v2` sub-client targets LandingAI's next-generation ADE gateway on it
 
 `client.v2.parseJobs`, `client.v2.extractJobs`, and `client.v2.buildSchemaJobs` all return a single, unified <a href="./src/resources/v2/types.ts">`Job`</a> shape even though the underlying parse/extract/build-schema job envelopes differ upstream — `Job.raw` retains the full original envelope as an escape hatch.
 
+A parse or extract job created with an `output_save_url` has its result delivered out-of-band; the completed job then carries `Job.metadata` (a `V2ParseMetadata` or `V2ExtractMetadata` receipt, billing included) next to `output_url` in `Job.raw` instead of an inline `result`. Inline jobs keep their metadata inside `result` and report `Job.metadata` as `null`.
+
 Types:
 
 - <code><a href="./src/resources/v2/types.ts">Job</a></code>
@@ -66,7 +68,9 @@ Types:
 - <code><a href="./src/resources/v2/types.ts">JobList</a></code>
 - <code><a href="./src/resources/v2/types.ts">JobStatus</a></code>
 - <code><a href="./src/resources/v2/types.ts">V2ParseResponse</a></code>
+- <code><a href="./src/resources/v2/types.ts">V2ParseMetadata</a></code>
 - <code><a href="./src/resources/v2/types.ts">V2ExtractResult</a></code>
+- <code><a href="./src/resources/v2/types.ts">V2ExtractMetadata</a></code>
 - <code><a href="./src/resources/v2/types.ts">V2BuildSchemaResult</a></code>
 - <code><a href="./src/resources/v2/types.ts">V2BuildSchemaMetadata</a></code>
 - <code><a href="./src/resources/v2/types.ts">BuildSchemaWarning</a></code>

--- a/specs/_generated/v2-aide.d.ts
+++ b/specs/_generated/v2-aide.d.ts
@@ -1560,6 +1560,8 @@ export interface operations {
                         };
                         /** @description The unique identifier for this v2-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
                         job_id?: string;
+                        /** @description The result's metadata block (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Same shape as the inline ``result``'s ``metadata``; inline jobs carry it there instead. */
+                        metadata?: Record<string, never> | null;
                         /** @description The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``. */
                         output_url?: string | null;
                         /** @description Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``. */
@@ -2008,6 +2010,8 @@ export interface operations {
                         };
                         /** @description The unique identifier for this parse job. Format: ``<service>-<26-character Crockford base32 ULID>`` matching ``^(parse|extract)-[0-9a-hjkmnp-tv-z]{26}$``. Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
                         job_id?: string;
+                        /** @description The parse metadata (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Inline jobs carry it inside ``result`` instead. */
+                        metadata?: components["schemas"]["ParseMetadata"] | null;
                         /** @description The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``. */
                         output_url?: string | null;
                         /** @description Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``. */

--- a/specs/v2-aide.json
+++ b/specs/v2-aide.json
@@ -2392,6 +2392,13 @@
                       "description": "The unique identifier for this v2-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
                       "type": "string"
                     },
+                    "metadata": {
+                      "description": "The result's metadata block (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Same shape as the inline ``result``'s ``metadata``; inline jobs carry it there instead.",
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
                     "output_url": {
                       "description": "The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``.",
                       "type": [
@@ -3116,6 +3123,17 @@
                     "job_id": {
                       "description": "The unique identifier for this parse job. Format: ``<service>-<26-character Crockford base32 ULID>`` matching ``^(parse|extract)-[0-9a-hjkmnp-tv-z]{26}$``. Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
                       "type": "string"
+                    },
+                    "metadata": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/ParseMetadata"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "The parse metadata (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Inline jobs carry it inside ``result`` instead."
                     },
                     "output_url": {
                       "description": "The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``.",

--- a/src/resources/v2/_normalize.ts
+++ b/src/resources/v2/_normalize.ts
@@ -9,7 +9,9 @@ import {
   JobError,
   JobStatus,
   V2BuildSchemaResult,
+  V2ExtractMetadata,
   V2ExtractResult,
+  V2ParseMetadata,
   V2ParseResponse,
   V2WorkflowResult,
   isTerminalStatus,
@@ -39,6 +41,15 @@ function toDate(value: unknown): Date | null {
 
 function toProgress(value: unknown): number | null {
   return typeof value === 'number' ? value : null;
+}
+
+/**
+ * Envelope-level `metadata`: the receipt (billing included) a delivered job
+ * returns next to `output_url` when `output_save_url` was set. `null` for inline
+ * jobs, whose metadata lives inside `result` instead.
+ */
+function toMetadata<T>(value: unknown): T | null {
+  return isRecord(value) ? (value as unknown as T) : null;
 }
 
 function toStatus(value: unknown): JobStatus {
@@ -109,6 +120,7 @@ export function normalizeParseJob(raw: Record<string, unknown>): Job {
     completed_at: toDate(raw['completed_at']),
     progress: toProgress(raw['progress']),
     result,
+    metadata: toMetadata<V2ParseMetadata>(raw['metadata']),
     // The get envelope carries `error {code, message}`; the list envelope a
     // `failure_reason` string. `isoError` handles both.
     error: isoError(raw),
@@ -121,6 +133,9 @@ export function normalizeExtractJob(raw: Record<string, unknown>): Job {
   const job = baseIsoJob(raw);
   const payload = raw['result'];
   job.result = isRecord(payload) ? (payload as unknown as V2ExtractResult) : null;
+  // Same shape as the inline `result`'s metadata, hoisted to the envelope for
+  // delivered (`output_save_url`) jobs.
+  job.metadata = toMetadata<V2ExtractMetadata>(raw['metadata']);
   return job;
 }
 

--- a/src/resources/v2/types.ts
+++ b/src/resources/v2/types.ts
@@ -41,6 +41,15 @@ export interface Job {
 
   result: V2ParseResponse | V2ExtractResult | V2BuildSchemaResult | V2GroundResult | V2WorkflowResult | null;
 
+  /**
+   * Envelope-level metadata (billing included), returned alongside `output_url`
+   * once a job created with an `output_save_url` has `completed` — the delivery
+   * moves the content, not the receipt. A `V2ParseMetadata` for parse jobs and a
+   * `V2ExtractMetadata` for extract jobs; `null` for inline jobs, which carry
+   * their metadata inside `result` instead.
+   */
+  metadata?: V2ParseMetadata | V2ExtractMetadata | null;
+
   error: JobError | null;
 
   /** `true` when `status` is `completed`, `failed`, or `cancelled`. */

--- a/tests/api-resources/v2/v2.test.ts
+++ b/tests/api-resources/v2/v2.test.ts
@@ -240,6 +240,73 @@ describe('client.v2 routing', () => {
     expect(result.metadata?.range_units).toBe('unicode_codepoints');
   });
 
+  test('parseJobs.get surfaces the envelope metadata alongside output_url', async () => {
+    // A job created with `output_save_url` has its result delivered out-of-band:
+    // the envelope carries `output_url` + the parse `metadata` receipt instead of
+    // an inline `result`.
+    const { client } = stubClient(() =>
+      jsonResponse({
+        job_id: 'pj-10',
+        status: 'completed',
+        created_at: '2026-01-02T03:04:05Z',
+        completed_at: '2026-01-02T03:05:06Z',
+        result: null,
+        output_url: 'https://example.com/delivered.json',
+        metadata: {
+          job_id: 'pj-10',
+          page_count: 3,
+          duration_ms: 1200,
+          billing: { service_tier: 'standard', total_credits: 3 },
+        },
+      }),
+    );
+    const job = await client.v2.parseJobs.get('pj-10');
+    expect(job.result).toBeNull();
+    const metadata = job.metadata as LandingAIADE.V2ParseMetadata;
+    expect(metadata.page_count).toBe(3);
+    expect(metadata.duration_ms).toBe(1200);
+    expect(metadata.billing?.total_credits).toBe(3);
+    expect(job.raw['output_url']).toBe('https://example.com/delivered.json');
+  });
+
+  test('extractJobs.get surfaces the envelope metadata alongside output_url', async () => {
+    const { client } = stubClient(() =>
+      jsonResponse({
+        job_id: 'ej-10',
+        status: 'completed',
+        created_at: '2026-01-02T03:04:05Z',
+        result: null,
+        output_url: 'https://example.com/delivered.json',
+        metadata: {
+          job_id: 'ej-10',
+          version: 'v',
+          model_version: 'dpt-3-pro-20260710',
+          duration_ms: 42,
+          billing: { total_credits: 2 },
+        },
+      }),
+    );
+    const job = await client.v2.extractJobs.get('ej-10');
+    expect(job.result).toBeNull();
+    const metadata = job.metadata as LandingAIADE.V2ExtractMetadata;
+    expect(metadata.model_version).toBe('dpt-3-pro-20260710');
+    expect(metadata.duration_ms).toBe(42);
+    expect(metadata.billing?.total_credits).toBe(2);
+  });
+
+  test('an inline job carries no envelope metadata (it lives inside result)', async () => {
+    const { client } = stubClient(() =>
+      jsonResponse({
+        job_id: 'pj-11',
+        status: 'completed',
+        result: { markdown: 'hi', metadata: { duration_ms: 5 } },
+      }),
+    );
+    const job = await client.v2.parseJobs.get('pj-11');
+    expect(job.metadata).toBeNull();
+    expect((job.result as LandingAIADE.V2ParseResponse).metadata?.duration_ms).toBe(5);
+  });
+
   test('parseJobs.get maps a failed job error object', async () => {
     const { client } = stubClient(() =>
       jsonResponse({ job_id: 'pj-f', status: 'failed', error: { code: 'bad', message: 'nope' } }),

--- a/tests/contract/v2-smoke.test.ts
+++ b/tests/contract/v2-smoke.test.ts
@@ -97,6 +97,27 @@ describe('V2 contract (staging)', () => {
   );
 
   runIf(
+    'parseJobs.get normalizes the envelope-level metadata receipt',
+    async () => {
+      const client = new LandingAIADE({ apikey: apiKey!, environment: 'staging' });
+      const list = await client.v2.parseJobs.list({ page: 0, page_size: 5 });
+      for (const listed of list.jobs) {
+        const job = await client.v2.parseJobs.get(listed.job_id);
+        // `metadata` is the receipt (billing included) returned next to
+        // `output_url` for jobs created with an `output_save_url`. A smoke test
+        // cannot mint a presigned delivery URL, so assert the normalizer's
+        // contract on whatever staging returns — an object or `null` — and
+        // require it whenever a completed job actually was delivered.
+        expect(job.metadata === null || typeof job.metadata === 'object').toBe(true);
+        if (job.status === 'completed' && typeof job.raw['output_url'] === 'string') {
+          expect(job.metadata).not.toBeNull();
+        }
+      }
+    },
+    60_000,
+  );
+
+  runIf(
     'parseJobs.list returns a normalized JobList against the new envelope',
     async () => {
       const client = new LandingAIADE({ apikey: apiKey!, environment: 'staging' });

--- a/tests/v2-normalize.test.ts
+++ b/tests/v2-normalize.test.ts
@@ -51,6 +51,28 @@ describe('normalizeParseJob', () => {
     expect(job.result).toBeNull();
   });
 
+  test('envelope metadata is surfaced for a delivered (output_save_url) job', () => {
+    const job = normalizeParseJob({
+      job_id: 'p3',
+      status: 'completed',
+      created_at: '2026-01-02T03:04:05Z',
+      output_url: 'https://example.com/delivered.json',
+      result: null,
+      metadata: { job_id: 'p3', page_count: 2, duration_ms: 7 },
+    });
+    expect(job.result).toBeNull(); // delivered out-of-band
+    expect((job.metadata as any)?.page_count).toBe(2);
+  });
+
+  test('envelope metadata is null for an inline job', () => {
+    const job = normalizeParseJob({
+      job_id: 'p4',
+      status: 'completed',
+      result: { markdown: '# hi', metadata: { duration_ms: 1 } },
+    });
+    expect(job.metadata).toBeNull();
+  });
+
   test('unknown status defaults to pending but preserves raw', () => {
     const job = normalizeParseJob({ job_id: 'p', status: 'some_brand_new_status' });
     expect(job.status).toBe('pending');
@@ -92,6 +114,33 @@ describe('normalizeExtractJob', () => {
   test('list envelope failure_reason maps to error.message', () => {
     const job = normalizeExtractJob({ job_id: 'e3', status: 'failed', failure_reason: 'nope' });
     expect(job.error?.message).toBe('nope');
+  });
+
+  test('envelope metadata is surfaced for a delivered (output_save_url) job', () => {
+    const job = normalizeExtractJob({
+      job_id: 'e4',
+      status: 'completed',
+      created_at: '2026-01-02T03:04:05Z',
+      output_url: 'https://example.com/delivered.json',
+      result: null,
+      metadata: { job_id: 'e4', version: 'v', duration_ms: 9, billing: { total_credits: 1 } },
+    });
+    expect(job.result).toBeNull(); // delivered out-of-band
+    expect((job.metadata as any)?.billing.total_credits).toBe(1);
+  });
+
+  test('envelope metadata is null for an inline job', () => {
+    const job = normalizeExtractJob({
+      job_id: 'e5',
+      status: 'completed',
+      result: {
+        extraction: {},
+        extraction_metadata: {},
+        markdown: '',
+        metadata: { job_id: 'e5', version: 'v', duration_ms: 1 },
+      },
+    });
+    expect(job.metadata).toBeNull();
   });
 });
 


### PR DESCRIPTION
Automated V2 spec-sync PR (`client.v2`).

- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference types.
- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff. The shipped-but-hand-maintained `/v2/workflow*` surface is not auto-wired, so workflow-only drift lands as a **mechanical-only PR** for a maintainer to reconcile by hand.

Gates (surface-lock, V2 contract tests, lint/build/test) must pass. The V2 ergonomic layer (unified Job, dual-host, schema coercion) is not in the spec, so when present the AI commit is a **draft a human finishes**. **Human review required before merge.**

<!-- what-changed:start -->
## What changed
_AI-generated from the PR diff — verify against the actual changes._

- **`client.v2.parseJobs` / `client.v2.extractJobs`**: the normalized `Job` now includes a `metadata` field — populated (as `V2ParseMetadata` / `V2ExtractMetadata`, billing included) for jobs delivered via `output_save_url` (alongside `output_url` in `Job.raw`); `null` for inline jobs, which continue to carry metadata inside `result`.
- **New types**: `V2ParseMetadata`, `V2ExtractMetadata` (exported from `src/resources/v2/types.ts`).
- **Spec (`specs/v2-aide.json`)**: added `metadata` field to the parse-job and extract-job response schemas (delivered-job envelope), matching the new client behavior.
- No route/method signature changes; `/v2/workflow*` spec snapshot untouched by this PR's client surface (no workflow client changes).
<!-- what-changed:end -->