### PR TITLE
spec-sync: track V2 spec drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ try {
 }
 ```
 
-The `create`, `get`, and `wait` methods return a normalized `Job` with `job_id`, `status` (`pending`, `processing`, `completed`, `failed`, or `cancelled`), `progress`, `result`, `error`, `is_terminal`, and `raw` (the unmodified API envelope, for any field not surfaced on the typed shape). The `list` method returns a `JobList` with a `jobs` array and `has_more`, plus the `page`/`page_size` pagination fields; `org_id` is populated only by older parse envelopes. Fields an endpoint doesn't populate are `null`.
+The `create`, `get`, and `wait` methods return a normalized `Job` with `job_id`, `status` (`pending`, `processing`, `completed`, `failed`, or `cancelled`), `progress`, `result`, `metadata`, `error`, `is_terminal`, and `raw` (the unmodified API envelope, for any field not surfaced on the typed shape). `progress` is an estimate rather than a measurement: it can jump forward and plateaus near `0.98`, so treat `status`/`is_terminal` — not `progress` — as the signal that a job finished. The `list` method returns a `JobList` with a `jobs` array and `has_more`, plus the `page`/`page_size` pagination fields; `org_id` is populated only by older parse envelopes. Fields an endpoint doesn't populate are `null`.
 
 ```ts
 // Poll manually instead of blocking
@@ -251,6 +251,20 @@ console.log(jobs.has_more);
 ```
 
 Extract jobs work the same way. The `create` method takes the same schema and Markdown arguments as `client.v2.extract`, plus `service_tier` and an optional `output_save_url` (a presigned URL the finished result is delivered to; the completed job then reports `output_url` in `Job.raw` instead of an inline `result`); it does not accept `saveTo`. Ground has no async jobs surface — use the synchronous `client.v2.ground` directly.
+
+The delivery moves the content, not the receipt: a job completed through `output_save_url` still reports its metadata block (billing included) on `Job.metadata`, so you can bill and audit the run without fetching the delivered payload back.
+
+```ts
+const done = await client.v2.parseJobs.wait(job.job_id);
+if (done.metadata) {
+  // Delivered to `output_save_url`; the content is at `done.raw.output_url`.
+  const metadata = done.metadata as LandingAIADE.V2ParseMetadata;
+  console.log(done.raw['output_url'], metadata.billing?.total_credits);
+} else {
+  // Inline job: the same metadata rides inside `result`.
+  console.log((done.result as LandingAIADE.V2ParseResponse | null)?.metadata.billing?.total_credits);
+}
+```
 
 ## Environments
 

--- a/api.md
+++ b/api.md
@@ -59,6 +59,8 @@ The `client.v2` sub-client targets LandingAI's next-generation ADE gateway on it
 
 `client.v2.parseJobs` and `client.v2.extractJobs` both return a single, unified <a href="./src/resources/v2/types.ts">`Job`</a> shape even though the underlying parse/extract job envelopes differ upstream — `Job.raw` retains the full original envelope as an escape hatch.
 
+`Job.metadata` is the envelope-level metadata receipt (billing included) that a completed job created with `output_save_url` carries alongside `output_url`, since the out-of-band delivery moves the content but not the receipt. It is `null` for inline jobs, which carry the same metadata inside `result`.
+
 Types:
 
 - <code><a href="./src/resources/v2/types.ts">Job</a></code>
@@ -66,7 +68,9 @@ Types:
 - <code><a href="./src/resources/v2/types.ts">JobList</a></code>
 - <code><a href="./src/resources/v2/types.ts">JobStatus</a></code>
 - <code><a href="./src/resources/v2/types.ts">V2ParseResponse</a></code>
+- <code><a href="./src/resources/v2/types.ts">V2ParseMetadata</a></code>
 - <code><a href="./src/resources/v2/types.ts">V2ExtractResult</a></code>
+- <code><a href="./src/resources/v2/types.ts">V2ExtractMetadata</a></code>
 - <code><a href="./src/resources/v2/types.ts">V2BuildSchemaResult</a></code>
 - <code><a href="./src/resources/v2/types.ts">V2BuildSchemaMetadata</a></code>
 - <code><a href="./src/resources/v2/types.ts">BuildSchemaWarning</a></code>

--- a/specs/_generated/v2-aide.d.ts
+++ b/specs/_generated/v2-aide.d.ts
@@ -24,70 +24,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v2/extract/build-schema": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * ADE Extract
-         * @description Generate or edit a JSON Schema for extraction from one or more source Markdown documents and/or a natural-language prompt. Runs synchronously and returns the result inline.
-         */
-        post: operations["v2-build-schema_run_sync"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v2/extract/build-schema/jobs": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * ADE List Extract Jobs
-         * @description List your Extract jobs, newest first.
-         */
-        get: operations["v2-build-schema_list_jobs"];
-        put?: never;
-        /**
-         * ADE Extract Jobs
-         * @description Generate or edit a JSON Schema for extraction from one or more source Markdown documents and/or a natural-language prompt. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.
-         */
-        post: operations["v2-build-schema_create_job"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v2/extract/build-schema/jobs/{job_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * ADE Get Extract Jobs
-         * @description Get the status of an async Extract job, including its result once the job has completed.
-         */
-        get: operations["v2-build-schema_get_job"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/v2/extract/jobs": {
         parameters: {
             query?: never;
@@ -1046,301 +982,6 @@ export interface operations {
             };
         };
     };
-    "v2-build-schema_run_sync": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /**
-                     * Markdown Urls
-                     * @description URLs to Markdown files to analyze for schema generation.
-                     * @default null
-                     */
-                    markdown_urls?: string[] | null;
-                    /**
-                     * Markdowns
-                     * @description Markdown files or inline content strings to analyze for schema generation. Multiple documents can be provided for better schema coverage.
-                     * @default null
-                     */
-                    markdowns?: string[] | null;
-                    /**
-                     * Prompt
-                     * @description Instructions for how to generate or modify the schema.
-                     * @default null
-                     */
-                    prompt?: string | null;
-                    /**
-                     * Schema
-                     * @description Existing JSON schema to iterate on or refine.
-                     * @default null
-                     */
-                    schema?: string | null;
-                };
-                "multipart/form-data": {
-                    /**
-                     * Markdown Urls
-                     * @description URLs to Markdown files to analyze for schema generation. JSON-serialized string in form data.
-                     * @default null
-                     */
-                    markdown_urls?: string[] | null;
-                    /** @description Repeat the field for each file upload. */
-                    markdowns?: (string)[];
-                    /**
-                     * Prompt
-                     * @description Instructions for how to generate or modify the schema. JSON-serialized string in form data.
-                     * @default null
-                     */
-                    prompt?: string | null;
-                    /**
-                     * Schema
-                     * @description Existing JSON schema to iterate on or refine. JSON-serialized string in form data.
-                     * @default null
-                     */
-                    schema?: string | null;
-                };
-            };
-        };
-        responses: {
-            /** @description v2-build-schema result */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /**
-                         * Extraction Schema
-                         * @description The generated JSON schema as a string.
-                         */
-                        extraction_schema: string;
-                        /** @description The metadata for the schema generation process. */
-                        metadata: components["schemas"]["V2BuildSchemaMetadata"];
-                    };
-                };
-            };
-            /** @description Request validation failed. */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    "v2-build-schema_list_jobs": {
-        parameters: {
-            query?: {
-                /** @description Page number (0-indexed). */
-                page?: number;
-                /** @description Number of items per page. */
-                page_size?: number;
-                /** @description Filter by job status. */
-                status?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description The caller's jobs, newest first */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        has_more?: boolean;
-                        jobs?: {
-                            completed_at?: string | null;
-                            created_at?: string | null;
-                            failure_reason?: string | null;
-                            /** @description The unique identifier for this v2-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
-                            job_id?: string;
-                            model_version?: string | null;
-                            /** @enum {string} */
-                            status?: "pending" | "processing" | "completed" | "failed";
-                        }[];
-                        page?: number;
-                        page_size?: number;
-                    };
-                };
-            };
-            /** @description Request validation failed. */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    "v2-build-schema_create_job": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /**
-                     * Markdown Urls
-                     * @description URLs to Markdown files to analyze for schema generation.
-                     * @default null
-                     */
-                    markdown_urls?: string[] | null;
-                    /**
-                     * Markdowns
-                     * @description Markdown files or inline content strings to analyze for schema generation. Multiple documents can be provided for better schema coverage.
-                     * @default null
-                     */
-                    markdowns?: string[] | null;
-                    /**
-                     * Prompt
-                     * @description Instructions for how to generate or modify the schema.
-                     * @default null
-                     */
-                    prompt?: string | null;
-                    /**
-                     * Schema
-                     * @description Existing JSON schema to iterate on or refine.
-                     * @default null
-                     */
-                    schema?: string | null;
-                    /** @description Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``. */
-                    service_tier?: ("standard" | "priority") | null;
-                };
-                "multipart/form-data": {
-                    /**
-                     * Markdown Urls
-                     * @description URLs to Markdown files to analyze for schema generation. JSON-serialized string in form data.
-                     * @default null
-                     */
-                    markdown_urls?: string[] | null;
-                    /** @description Repeat the field for each file upload. */
-                    markdowns?: (string)[];
-                    /**
-                     * Prompt
-                     * @description Instructions for how to generate or modify the schema. JSON-serialized string in form data.
-                     * @default null
-                     */
-                    prompt?: string | null;
-                    /**
-                     * Schema
-                     * @description Existing JSON schema to iterate on or refine. JSON-serialized string in form data.
-                     * @default null
-                     */
-                    schema?: string | null;
-                    /** @description Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``. */
-                    service_tier?: ("standard" | "priority") | null;
-                };
-            };
-        };
-        responses: {
-            /** @description Job created */
-            202: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        created_at?: string | null;
-                        /** @description The unique identifier for this v2-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
-                        job_id?: string;
-                        /** @enum {string} */
-                        status?: "pending" | "processing" | "completed" | "failed";
-                    };
-                };
-            };
-            /** @description Request validation failed. */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    "v2-build-schema_get_job": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The identifier of the job to retrieve, as returned by the create-job request. */
-                job_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Job status / result */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @description Present once the job is terminal. */
-                        completed_at?: string;
-                        created_at?: string | null;
-                        /** @description Present once status is ``failed``. */
-                        error?: {
-                            /** @description Stable error code (``internal_error`` when unmapped). */
-                            code?: string;
-                            message?: string;
-                        };
-                        /** @description The unique identifier for this v2-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
-                        job_id?: string;
-                        /** @description Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``. */
-                        progress?: number;
-                        /** @description Present once status is ``completed``. */
-                        result?: {
-                            /**
-                             * Extraction Schema
-                             * @description The generated JSON schema as a string.
-                             */
-                            extraction_schema: string;
-                            /** @description The metadata for the schema generation process. */
-                            metadata: components["schemas"]["V2BuildSchemaMetadata"];
-                        } | null;
-                        /** @enum {string} */
-                        status?: "pending" | "processing" | "completed" | "failed";
-                    };
-                };
-            };
-            /** @description Not found (e.g. no such job). */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Request validation failed. */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
     "v2-extract_list_jobs": {
         parameters: {
             query?: {
@@ -1560,9 +1201,11 @@ export interface operations {
                         };
                         /** @description The unique identifier for this v2-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
                         job_id?: string;
+                        /** @description The result's metadata block (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Same shape as the inline ``result``'s ``metadata``; inline jobs carry it there instead. */
+                        metadata?: Record<string, never> | null;
                         /** @description The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``. */
                         output_url?: string | null;
-                        /** @description Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``. */
+                        /** @description Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``. */
                         progress?: number;
                         /** @description Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead. */
                         result?: {
@@ -2008,6 +1651,8 @@ export interface operations {
                         };
                         /** @description The unique identifier for this parse job. Format: ``<service>-<26-character Crockford base32 ULID>`` matching ``^(parse|extract)-[0-9a-hjkmnp-tv-z]{26}$``. Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
                         job_id?: string;
+                        /** @description The parse metadata (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Inline jobs carry it inside ``result`` instead. */
+                        metadata?: components["schemas"]["ParseMetadata"] | null;
                         /** @description The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``. */
                         output_url?: string | null;
                         /** @description Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``. */
@@ -2386,7 +2031,7 @@ export interface operations {
                         };
                         /** @description The unique identifier for this v2-workflow job. Format: ``v2-workflow-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
                         job_id?: string;
-                        /** @description Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``. */
+                        /** @description Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``. */
                         progress?: number;
                         /** @description Present once status is ``completed``. */
                         result?: {

--- a/specs/v2-aide.json
+++ b/specs/v2-aide.json
@@ -1724,6 +1724,13 @@
                       "description": "The unique identifier for this v2-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
                       "type": "string"
                     },
+                    "metadata": {
+                      "description": "The result's metadata block (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Same shape as the inline ``result``'s ``metadata``; inline jobs carry it there instead.",
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
                     "output_url": {
                       "description": "The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``.",
                       "type": [
@@ -1732,7 +1739,7 @@
                       ]
                     },
                     "progress": {
-                      "description": "Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``.",
+                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
                       "maximum": 1,
                       "minimum": 0,
                       "type": "number"
@@ -2449,6 +2456,17 @@
                       "description": "The unique identifier for this parse job. Format: ``<service>-<26-character Crockford base32 ULID>`` matching ``^(parse|extract)-[0-9a-hjkmnp-tv-z]{26}$``. Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
                       "type": "string"
                     },
+                    "metadata": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/ParseMetadata"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "The parse metadata (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Inline jobs carry it inside ``result`` instead."
+                    },
                     "output_url": {
                       "description": "The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``.",
                       "type": [
@@ -3108,7 +3126,7 @@
                       "type": "string"
                     },
                     "progress": {
-                      "description": "Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``.",
+                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
                       "maximum": 1,
                       "minimum": 0,
                       "type": "number"

--- a/src/resources/v2/_normalize.ts
+++ b/src/resources/v2/_normalize.ts
@@ -41,6 +41,16 @@ function toProgress(value: unknown): number | null {
   return typeof value === 'number' ? value : null;
 }
 
+/**
+ * Envelope-level `metadata`: the receipt a completed `output_save_url` job
+ * keeps alongside `output_url` after the result itself was delivered
+ * out-of-band. Inline jobs carry their metadata inside `result`, so the
+ * envelope field is absent and normalizes to `null`.
+ */
+function toMetadata(value: unknown): Job['metadata'] {
+  return isRecord(value) ? value : null;
+}
+
 function toStatus(value: unknown): JobStatus {
   // Unknown/renamed status from the gateway must not crash the normalizer; the
   // original raw status is still available via `job.raw`.
@@ -84,6 +94,7 @@ function baseIsoJob(raw: Record<string, unknown>): Job {
     completed_at: toDate(raw['completed_at']),
     progress: toProgress(raw['progress']),
     result: null,
+    metadata: toMetadata(raw['metadata']),
     error: isoError(raw),
     is_terminal: isTerminalStatus(status),
     raw,
@@ -109,6 +120,7 @@ export function normalizeParseJob(raw: Record<string, unknown>): Job {
     completed_at: toDate(raw['completed_at']),
     progress: toProgress(raw['progress']),
     result,
+    metadata: toMetadata(raw['metadata']),
     // The get envelope carries `error {code, message}`; the list envelope a
     // `failure_reason` string. `isoError` handles both.
     error: isoError(raw),

--- a/src/resources/v2/types.ts
+++ b/src/resources/v2/types.ts
@@ -41,6 +41,16 @@ export interface Job {
 
   result: V2ParseResponse | V2ExtractResult | V2BuildSchemaResult | V2GroundResult | V2WorkflowResult | null;
 
+  /**
+   * The result's metadata block (billing included), carried on the envelope
+   * alongside `raw.output_url` once a job created with `output_save_url` has
+   * completed — the out-of-band delivery moves the content, not the receipt.
+   * `null` for inline jobs, which carry the same metadata inside `result`
+   * instead. A `V2ParseMetadata` for parse jobs; the extract envelope declares
+   * it as an untyped object, so it widens to `Record<string, unknown>` there.
+   */
+  metadata: V2ParseMetadata | V2ExtractMetadata | Record<string, unknown> | null;
+
   error: JobError | null;
 
   /** `true` when `status` is `completed`, `failed`, or `cancelled`. */

--- a/tests/api-resources/v2/v2.test.ts
+++ b/tests/api-resources/v2/v2.test.ts
@@ -240,6 +240,65 @@ describe('client.v2 routing', () => {
     expect(result.metadata?.range_units).toBe('unicode_codepoints');
   });
 
+  test('parseJobs.get surfaces the envelope metadata receipt beside output_url', async () => {
+    const { client } = stubClient(() =>
+      jsonResponse({
+        job_id: 'pj-zdr',
+        status: 'completed',
+        completed_at: '2026-01-02T03:05:06Z',
+        // A job created with `output_save_url`: the parsed content went to the
+        // presigned URL, and only the metadata receipt rides on the envelope.
+        output_url: 'https://example.com/delivered.json',
+        result: null,
+        metadata: {
+          job_id: 'pj-zdr',
+          page_count: 3,
+          duration_ms: 1200,
+          billing: { service_tier: 'standard', total_credits: 6 },
+        },
+      }),
+    );
+    const job = await client.v2.parseJobs.get('pj-zdr');
+    expect(job.result).toBeNull(); // delivered out-of-band instead
+    expect(job.raw['output_url']).toBe('https://example.com/delivered.json');
+    const metadata = job.metadata as LandingAIADE.V2ParseMetadata;
+    expect(metadata.page_count).toBe(3);
+    expect(metadata.billing?.total_credits).toBe(6);
+  });
+
+  test('extractJobs.get surfaces the envelope metadata receipt beside output_url', async () => {
+    const { client } = stubClient(() =>
+      jsonResponse({
+        job_id: 'ej-zdr',
+        status: 'completed',
+        created_at: '2026-01-02T03:04:05Z',
+        output_url: 'https://example.com/delivered.json',
+        metadata: { job_id: 'ej-zdr', duration_ms: 42, billing: { total_credits: 2 } },
+      }),
+    );
+    const job = await client.v2.extractJobs.get('ej-zdr');
+    expect(job.result).toBeNull();
+    expect((job.metadata as Record<string, unknown>)['duration_ms']).toBe(42);
+  });
+
+  test('an inline job reports a null envelope metadata (it rides inside result)', async () => {
+    const { client } = stubClient(() =>
+      jsonResponse({
+        job_id: 'ej-inline',
+        status: 'completed',
+        result: {
+          extraction: {},
+          extraction_metadata: {},
+          markdown: '',
+          metadata: { job_id: 'ej-inline', version: 'v', duration_ms: 1 },
+        },
+      }),
+    );
+    const job = await client.v2.extractJobs.get('ej-inline');
+    expect(job.metadata).toBeNull();
+    expect((job.result as LandingAIADE.V2ExtractResult).metadata.duration_ms).toBe(1);
+  });
+
   test('parseJobs.get maps a failed job error object', async () => {
     const { client } = stubClient(() =>
       jsonResponse({ job_id: 'pj-f', status: 'failed', error: { code: 'bad', message: 'nope' } }),

--- a/tests/contract/v2-smoke.test.ts
+++ b/tests/contract/v2-smoke.test.ts
@@ -67,6 +67,29 @@ describe('V2 contract (staging)', () => {
   );
 
   runIf(
+    'an inline extract job leaves the new envelope-level metadata receipt null',
+    async () => {
+      const client = new LandingAIADE({ apikey: apiKey!, environment: 'staging' });
+      const created = await client.v2.extractJobs.create({
+        schema: { type: 'object', properties: { revenue: { type: 'string' } } },
+        markdown: SAMPLE_MARKDOWN,
+      });
+      const done = await client.v2.extractJobs.wait(created.job_id, { timeout: 90_000 });
+      // `metadata` (added by this spec sync) is the receipt for an out-of-band
+      // delivery: the gateway populates it only alongside `output_url`, for jobs
+      // created with `output_save_url`. This job is inline, so it must normalize
+      // to `null` and the metadata must ride inside `result` instead.
+      expect(done.metadata === null || typeof done.metadata === 'object').toBe(true);
+      if (done.status === 'completed') {
+        expect(done.metadata).toBeNull();
+        const result = done.result as LandingAIADE.V2ExtractResult | null;
+        expect(typeof result?.metadata.duration_ms).toBe('number');
+      }
+    },
+    120_000,
+  );
+
+  runIf(
     'parseJobs.list returns a normalized JobList against the new envelope',
     async () => {
       const client = new LandingAIADE({ apikey: apiKey!, environment: 'staging' });

--- a/tests/v2-normalize.test.ts
+++ b/tests/v2-normalize.test.ts
@@ -51,6 +51,32 @@ describe('normalizeParseJob', () => {
     expect(job.result).toBeNull();
   });
 
+  test('envelope metadata is surfaced when the result was delivered to output_save_url', () => {
+    const job = normalizeParseJob({
+      job_id: 'p3',
+      status: 'completed',
+      completed_at: '2026-01-02T03:04:05Z',
+      output_url: 'https://example.com/out.json',
+      result: null,
+      metadata: { job_id: 'p3', page_count: 2, duration_ms: 900 },
+    });
+    expect(job.result).toBeNull();
+    expect((job.metadata as any).page_count).toBe(2);
+    expect(job.raw['output_url']).toBe('https://example.com/out.json');
+  });
+
+  test('envelope metadata is null for an inline job and for a non-object value', () => {
+    const inline = normalizeParseJob({
+      job_id: 'p4',
+      status: 'completed',
+      result: { markdown: '# hi', metadata: { job_id: 'p4' } },
+    });
+    expect(inline.metadata).toBeNull();
+    // A scalar/array where an object was expected must not leak through.
+    expect(normalizeParseJob({ job_id: 'p5', metadata: 'nope' }).metadata).toBeNull();
+    expect(normalizeParseJob({ job_id: 'p6', metadata: [] }).metadata).toBeNull();
+  });
+
   test('unknown status defaults to pending but preserves raw', () => {
     const job = normalizeParseJob({ job_id: 'p', status: 'some_brand_new_status' });
     expect(job.status).toBe('pending');
@@ -92,6 +118,18 @@ describe('normalizeExtractJob', () => {
   test('list envelope failure_reason maps to error.message', () => {
     const job = normalizeExtractJob({ job_id: 'e3', status: 'failed', failure_reason: 'nope' });
     expect(job.error?.message).toBe('nope');
+  });
+
+  test('envelope metadata rides alongside output_url on a delivered job', () => {
+    const job = normalizeExtractJob({
+      job_id: 'e4',
+      status: 'completed',
+      completed_at: '2026-01-02T03:04:09Z',
+      output_url: 'https://example.com/out.json',
+      metadata: { job_id: 'e4', duration_ms: 10, billing: { total_credits: 3 } },
+    });
+    expect(job.result).toBeNull();
+    expect((job.metadata as any).billing.total_credits).toBe(3);
   });
 });
 

--- a/tests/v2-waiter.test.ts
+++ b/tests/v2-waiter.test.ts
@@ -10,6 +10,7 @@ function makeJob(status: JobStatus, error: Job['error'] = null): Job {
     completed_at: null,
     progress: null,
     result: null,
+    metadata: null,
     error,
     is_terminal: status === 'completed' || status === 'failed' || status === 'cancelled',
     raw: {},


### PR DESCRIPTION
Automated V2 spec-sync PR (`client.v2`).

- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference types.
- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff. The shipped-but-hand-maintained `/v2/workflow*` surface is not auto-wired, so workflow-only drift lands as a **mechanical-only PR** for a maintainer to reconcile by hand.

Gates (surface-lock, V2 contract tests, lint/build/test) must pass. The V2 ergonomic layer (unified Job, dual-host, schema coercion) is not in the spec, so when present the AI commit is a **draft a human finishes**. **Human review required before merge.**