### PR TITLE
spec-sync: track V2 spec drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ try {
 }
 ```
 
-The `create`, `get`, and `wait` methods return a normalized `Job` with `job_id`, `status` (`pending`, `processing`, `completed`, `failed`, or `cancelled`), `progress`, `result`, `error`, `is_terminal`, and `raw` (the unmodified API envelope, for any field not surfaced on the typed shape). The `list` method returns a `JobList` with a `jobs` array and `has_more`, plus the `page`/`page_size` pagination fields; `org_id` is populated only by older parse envelopes. Fields an endpoint doesn't populate are `null`.
+The `create`, `get`, and `wait` methods return a normalized `Job` with `job_id`, `status` (`pending`, `processing`, `completed`, `failed`, or `cancelled`), `progress`, `result`, `metadata`, `error`, `is_terminal`, and `raw` (the unmodified API envelope, for any field not surfaced on the typed shape). `progress` is an estimate, not a measurement: it approaches but never reaches 1 (long-running jobs plateau near 0.98), so key completion off `status`, which can go terminal from any progress value. The `list` method returns a `JobList` with a `jobs` array and `has_more`, plus the `page`/`page_size` pagination fields; `org_id` is populated only by older parse envelopes. Fields an endpoint doesn't populate are `null`.
 
 ```ts
 // Poll manually instead of blocking
@@ -250,7 +250,17 @@ for (const j of jobs.jobs) {
 console.log(jobs.has_more);
 ```
 
-Extract jobs work the same way. The `create` method takes the same schema and Markdown arguments as `client.v2.extract`, plus `service_tier` and an optional `output_save_url` (a presigned URL the finished result is delivered to; the completed job then reports `output_url` in `Job.raw` instead of an inline `result`); it does not accept `saveTo`. Ground has no async jobs surface — use the synchronous `client.v2.ground` directly.
+Extract jobs work the same way. The `create` method takes the same schema and Markdown arguments as `client.v2.extract`, plus `service_tier` and an optional `output_save_url` (a presigned URL the finished result is delivered to; the completed job then reports `output_url` in `Job.raw` instead of an inline `result`); it does not accept `saveTo`. The delivery moves the content, not the receipt: a completed job whose result went to an `output_save_url` still returns its metadata block — billing included — on `Job.metadata`, while an inline job leaves `Job.metadata` `null` and carries the same block inside `result.metadata`.
+
+```ts
+// A job whose result was delivered out-of-band still reports its metadata receipt
+const delivered = await client.v2.parseJobs.wait(job.job_id);
+console.log(delivered.raw['output_url']); // where the parse output was PUT
+const receipt = delivered.metadata as LandingAIADE.V2ParseMetadata | null;
+console.log(receipt?.page_count, receipt?.billing?.total_credits);
+```
+
+Ground has no async jobs surface — use the synchronous `client.v2.ground` directly.
 
 ## Environments
 

--- a/api.md
+++ b/api.md
@@ -57,7 +57,7 @@ Methods:
 
 The `client.v2` sub-client targets LandingAI's next-generation ADE gateway on its own host (`api.ade.[env].landing.ai`), separate from the V1 host (`api.va.[env].landing.ai`). It is **additive** — `client.v2.*` is a separate surface from the top-level `client.*` (V1) methods above, and using it does not change any V1 behavior.
 
-`client.v2.parseJobs` and `client.v2.extractJobs` both return a single, unified <a href="./src/resources/v2/types.ts">`Job`</a> shape even though the underlying parse/extract job envelopes differ upstream — `Job.raw` retains the full original envelope as an escape hatch.
+`client.v2.parseJobs` and `client.v2.extractJobs` both return a single, unified <a href="./src/resources/v2/types.ts">`Job`</a> shape even though the underlying parse/extract job envelopes differ upstream — `Job.raw` retains the full original envelope as an escape hatch. `Job.metadata` carries the envelope's top-level metadata receipt (a <a href="./src/resources/v2/types.ts">`V2ParseMetadata`</a> for parse jobs), returned alongside `raw.output_url` when a job created with `output_save_url` completes; it is `null` for inline jobs, whose metadata lives on `Job.result`.
 
 Types:
 
@@ -66,6 +66,7 @@ Types:
 - <code><a href="./src/resources/v2/types.ts">JobList</a></code>
 - <code><a href="./src/resources/v2/types.ts">JobStatus</a></code>
 - <code><a href="./src/resources/v2/types.ts">V2ParseResponse</a></code>
+- <code><a href="./src/resources/v2/types.ts">V2ParseMetadata</a></code>
 - <code><a href="./src/resources/v2/types.ts">V2ExtractResult</a></code>
 - <code><a href="./src/resources/v2/types.ts">V2BuildSchemaResult</a></code>
 - <code><a href="./src/resources/v2/types.ts">V2BuildSchemaMetadata</a></code>

--- a/specs/_generated/v2-aide.d.ts
+++ b/specs/_generated/v2-aide.d.ts
@@ -24,70 +24,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v2/extract/build-schema": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * ADE Extract
-         * @description Generate or edit a JSON Schema for extraction from one or more source Markdown documents and/or a natural-language prompt. Runs synchronously and returns the result inline.
-         */
-        post: operations["v2-build-schema_run_sync"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v2/extract/build-schema/jobs": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * ADE List Extract Jobs
-         * @description List your Extract jobs, newest first.
-         */
-        get: operations["v2-build-schema_list_jobs"];
-        put?: never;
-        /**
-         * ADE Extract Jobs
-         * @description Generate or edit a JSON Schema for extraction from one or more source Markdown documents and/or a natural-language prompt. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.
-         */
-        post: operations["v2-build-schema_create_job"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v2/extract/build-schema/jobs/{job_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * ADE Get Extract Jobs
-         * @description Get the status of an async Extract job, including its result once the job has completed.
-         */
-        get: operations["v2-build-schema_get_job"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/v2/extract/jobs": {
         parameters: {
             query?: never;
@@ -1046,301 +982,6 @@ export interface operations {
             };
         };
     };
-    "v2-build-schema_run_sync": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /**
-                     * Markdown Urls
-                     * @description URLs to Markdown files to analyze for schema generation.
-                     * @default null
-                     */
-                    markdown_urls?: string[] | null;
-                    /**
-                     * Markdowns
-                     * @description Markdown files or inline content strings to analyze for schema generation. Multiple documents can be provided for better schema coverage.
-                     * @default null
-                     */
-                    markdowns?: string[] | null;
-                    /**
-                     * Prompt
-                     * @description Instructions for how to generate or modify the schema.
-                     * @default null
-                     */
-                    prompt?: string | null;
-                    /**
-                     * Schema
-                     * @description Existing JSON schema to iterate on or refine.
-                     * @default null
-                     */
-                    schema?: string | null;
-                };
-                "multipart/form-data": {
-                    /**
-                     * Markdown Urls
-                     * @description URLs to Markdown files to analyze for schema generation. JSON-serialized string in form data.
-                     * @default null
-                     */
-                    markdown_urls?: string[] | null;
-                    /** @description Repeat the field for each file upload. */
-                    markdowns?: (string)[];
-                    /**
-                     * Prompt
-                     * @description Instructions for how to generate or modify the schema. JSON-serialized string in form data.
-                     * @default null
-                     */
-                    prompt?: string | null;
-                    /**
-                     * Schema
-                     * @description Existing JSON schema to iterate on or refine. JSON-serialized string in form data.
-                     * @default null
-                     */
-                    schema?: string | null;
-                };
-            };
-        };
-        responses: {
-            /** @description v2-build-schema result */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /**
-                         * Extraction Schema
-                         * @description The generated JSON schema as a string.
-                         */
-                        extraction_schema: string;
-                        /** @description The metadata for the schema generation process. */
-                        metadata: components["schemas"]["V2BuildSchemaMetadata"];
-                    };
-                };
-            };
-            /** @description Request validation failed. */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    "v2-build-schema_list_jobs": {
-        parameters: {
-            query?: {
-                /** @description Page number (0-indexed). */
-                page?: number;
-                /** @description Number of items per page. */
-                page_size?: number;
-                /** @description Filter by job status. */
-                status?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description The caller's jobs, newest first */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        has_more?: boolean;
-                        jobs?: {
-                            completed_at?: string | null;
-                            created_at?: string | null;
-                            failure_reason?: string | null;
-                            /** @description The unique identifier for this v2-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
-                            job_id?: string;
-                            model_version?: string | null;
-                            /** @enum {string} */
-                            status?: "pending" | "processing" | "completed" | "failed";
-                        }[];
-                        page?: number;
-                        page_size?: number;
-                    };
-                };
-            };
-            /** @description Request validation failed. */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    "v2-build-schema_create_job": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /**
-                     * Markdown Urls
-                     * @description URLs to Markdown files to analyze for schema generation.
-                     * @default null
-                     */
-                    markdown_urls?: string[] | null;
-                    /**
-                     * Markdowns
-                     * @description Markdown files or inline content strings to analyze for schema generation. Multiple documents can be provided for better schema coverage.
-                     * @default null
-                     */
-                    markdowns?: string[] | null;
-                    /**
-                     * Prompt
-                     * @description Instructions for how to generate or modify the schema.
-                     * @default null
-                     */
-                    prompt?: string | null;
-                    /**
-                     * Schema
-                     * @description Existing JSON schema to iterate on or refine.
-                     * @default null
-                     */
-                    schema?: string | null;
-                    /** @description Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``. */
-                    service_tier?: ("standard" | "priority") | null;
-                };
-                "multipart/form-data": {
-                    /**
-                     * Markdown Urls
-                     * @description URLs to Markdown files to analyze for schema generation. JSON-serialized string in form data.
-                     * @default null
-                     */
-                    markdown_urls?: string[] | null;
-                    /** @description Repeat the field for each file upload. */
-                    markdowns?: (string)[];
-                    /**
-                     * Prompt
-                     * @description Instructions for how to generate or modify the schema. JSON-serialized string in form data.
-                     * @default null
-                     */
-                    prompt?: string | null;
-                    /**
-                     * Schema
-                     * @description Existing JSON schema to iterate on or refine. JSON-serialized string in form data.
-                     * @default null
-                     */
-                    schema?: string | null;
-                    /** @description Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``. */
-                    service_tier?: ("standard" | "priority") | null;
-                };
-            };
-        };
-        responses: {
-            /** @description Job created */
-            202: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        created_at?: string | null;
-                        /** @description The unique identifier for this v2-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
-                        job_id?: string;
-                        /** @enum {string} */
-                        status?: "pending" | "processing" | "completed" | "failed";
-                    };
-                };
-            };
-            /** @description Request validation failed. */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    "v2-build-schema_get_job": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The identifier of the job to retrieve, as returned by the create-job request. */
-                job_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Job status / result */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @description Present once the job is terminal. */
-                        completed_at?: string;
-                        created_at?: string | null;
-                        /** @description Present once status is ``failed``. */
-                        error?: {
-                            /** @description Stable error code (``internal_error`` when unmapped). */
-                            code?: string;
-                            message?: string;
-                        };
-                        /** @description The unique identifier for this v2-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
-                        job_id?: string;
-                        /** @description Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``. */
-                        progress?: number;
-                        /** @description Present once status is ``completed``. */
-                        result?: {
-                            /**
-                             * Extraction Schema
-                             * @description The generated JSON schema as a string.
-                             */
-                            extraction_schema: string;
-                            /** @description The metadata for the schema generation process. */
-                            metadata: components["schemas"]["V2BuildSchemaMetadata"];
-                        } | null;
-                        /** @enum {string} */
-                        status?: "pending" | "processing" | "completed" | "failed";
-                    };
-                };
-            };
-            /** @description Not found (e.g. no such job). */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Request validation failed. */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
     "v2-extract_list_jobs": {
         parameters: {
             query?: {
@@ -1560,9 +1201,11 @@ export interface operations {
                         };
                         /** @description The unique identifier for this v2-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
                         job_id?: string;
+                        /** @description The result's metadata block (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Same shape as the inline ``result``'s ``metadata``; inline jobs carry it there instead. */
+                        metadata?: Record<string, never> | null;
                         /** @description The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``. */
                         output_url?: string | null;
-                        /** @description Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``. */
+                        /** @description Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``. */
                         progress?: number;
                         /** @description Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead. */
                         result?: {
@@ -2008,6 +1651,8 @@ export interface operations {
                         };
                         /** @description The unique identifier for this parse job. Format: ``<service>-<26-character Crockford base32 ULID>`` matching ``^(parse|extract)-[0-9a-hjkmnp-tv-z]{26}$``. Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
                         job_id?: string;
+                        /** @description The parse metadata (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Inline jobs carry it inside ``result`` instead. */
+                        metadata?: components["schemas"]["ParseMetadata"] | null;
                         /** @description The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``. */
                         output_url?: string | null;
                         /** @description Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``. */
@@ -2386,7 +2031,7 @@ export interface operations {
                         };
                         /** @description The unique identifier for this v2-workflow job. Format: ``v2-workflow-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
                         job_id?: string;
-                        /** @description Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``. */
+                        /** @description Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``. */
                         progress?: number;
                         /** @description Present once status is ``completed``. */
                         result?: {

--- a/specs/v2-aide.json
+++ b/specs/v2-aide.json
@@ -1724,6 +1724,13 @@
                       "description": "The unique identifier for this v2-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
                       "type": "string"
                     },
+                    "metadata": {
+                      "description": "The result's metadata block (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Same shape as the inline ``result``'s ``metadata``; inline jobs carry it there instead.",
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
                     "output_url": {
                       "description": "The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``.",
                       "type": [
@@ -1732,7 +1739,7 @@
                       ]
                     },
                     "progress": {
-                      "description": "Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``.",
+                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
                       "maximum": 1,
                       "minimum": 0,
                       "type": "number"
@@ -2449,6 +2456,17 @@
                       "description": "The unique identifier for this parse job. Format: ``<service>-<26-character Crockford base32 ULID>`` matching ``^(parse|extract)-[0-9a-hjkmnp-tv-z]{26}$``. Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
                       "type": "string"
                     },
+                    "metadata": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/ParseMetadata"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "The parse metadata (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Inline jobs carry it inside ``result`` instead."
+                    },
                     "output_url": {
                       "description": "The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``.",
                       "type": [
@@ -3108,7 +3126,7 @@
                       "type": "string"
                     },
                     "progress": {
-                      "description": "Job completion as a decimal from 0 (not started) to 1 (complete). Present while ``processing``.",
+                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
                       "maximum": 1,
                       "minimum": 0,
                       "type": "number"

--- a/src/resources/v2/_normalize.ts
+++ b/src/resources/v2/_normalize.ts
@@ -56,6 +56,16 @@ function toStatus(value: unknown): JobStatus {
   return 'pending';
 }
 
+/**
+ * Top-level envelope `metadata`: the receipt (billing included) a completed job
+ * returns alongside `output_url` when its result was delivered to an
+ * `output_save_url`. Absent on inline jobs, which carry it inside `result`.
+ */
+function toMetadata(raw: Record<string, unknown>): Record<string, unknown> | null {
+  const metadata = raw['metadata'];
+  return isRecord(metadata) ? metadata : null;
+}
+
 /** Extract job error: an `error {code, message}` object, or a `failure_reason` string (list envelope). */
 function isoError(raw: Record<string, unknown>): JobError | null {
   const err = raw['error'];
@@ -109,6 +119,9 @@ export function normalizeParseJob(raw: Record<string, unknown>): Job {
     completed_at: toDate(raw['completed_at']),
     progress: toProgress(raw['progress']),
     result,
+    // Typed as `V2ParseMetadata` upstream; kept as the raw record so an
+    // unrecognized field is never dropped (see `Job.metadata`).
+    metadata: toMetadata(raw),
     // The get envelope carries `error {code, message}`; the list envelope a
     // `failure_reason` string. `isoError` handles both.
     error: isoError(raw),
@@ -121,6 +134,9 @@ export function normalizeExtractJob(raw: Record<string, unknown>): Job {
   const job = baseIsoJob(raw);
   const payload = raw['result'];
   job.result = isRecord(payload) ? (payload as unknown as V2ExtractResult) : null;
+  // Same receipt-alongside-`output_url` block as parse; the extract envelope
+  // types it as a bare object upstream.
+  job.metadata = toMetadata(raw);
   return job;
 }
 

--- a/src/resources/v2/extract.ts
+++ b/src/resources/v2/extract.ts
@@ -48,8 +48,9 @@ export interface V2ExtractJobCreateParams extends V2ExtractParams {
    * URL to save the result to — e.g. a presigned S3 PUT URL. Async jobs only.
    * When set, the finished result is delivered (HTTP PUT) to this URL and the
    * completed job reports `output_url` (in `Job.raw`) instead of an inline
-   * `result`. Must be a public http(s) URL; private/loopback IPs are rejected
-   * at submit time.
+   * `result` — the metadata receipt (billing included) still comes back on
+   * `Job.metadata`. Must be a public http(s) URL; private/loopback IPs are
+   * rejected at submit time.
    */
   output_save_url?: string | null;
 }

--- a/src/resources/v2/parse.ts
+++ b/src/resources/v2/parse.ts
@@ -37,7 +37,9 @@ export interface V2ParseParams {
 export interface V2ParseJobCreateParams extends V2ParseParams {
   /**
    * If zero data retention (ZDR) is enabled, a URL the parsed output should be
-   * saved to instead of being returned in the job result.
+   * saved to instead of being returned in the job result. The completed job
+   * then reports `output_url` (in `Job.raw`) instead of an inline `result`, and
+   * the parse metadata receipt (billing included) on `Job.metadata`.
    */
   output_save_url?: string | null;
 

--- a/src/resources/v2/types.ts
+++ b/src/resources/v2/types.ts
@@ -37,9 +37,27 @@ export interface Job {
 
   completed_at: Date | null;
 
+  /**
+   * Estimated completion as a decimal from 0 to 1 while `processing` — an
+   * estimate, not a measurement: it typically advances between polls, may jump
+   * forward when the service reports a real milestone (e.g. parsed pages), and
+   * approaches but never reaches 1 (long-running jobs plateau near 0.98).
+   * Completion is signalled by `status`, and a job may complete from any
+   * progress value.
+   */
   progress: number | null;
 
   result: V2ParseResponse | V2ExtractResult | V2BuildSchemaResult | V2GroundResult | V2WorkflowResult | null;
+
+  /**
+   * The result's metadata block (billing included), present alongside
+   * `raw.output_url` once a job created with `output_save_url` has `completed`
+   * — the delivery moves the content, not the receipt. Parse jobs carry a
+   * `V2ParseMetadata`; extract jobs carry an untyped block of the same shape as
+   * their inline `result.metadata`. `null` for inline jobs, which carry their
+   * metadata inside `result` instead.
+   */
+  metadata?: V2ParseMetadata | Record<string, unknown> | null;
 
   error: JobError | null;
 

--- a/tests/api-resources/v2/v2.test.ts
+++ b/tests/api-resources/v2/v2.test.ts
@@ -240,6 +240,63 @@ describe('client.v2 routing', () => {
     expect(result.metadata?.range_units).toBe('unicode_codepoints');
   });
 
+  test('parseJobs.get surfaces the delivered-result metadata receipt', async () => {
+    // With `output_save_url` set, the content goes to the URL and the envelope
+    // returns `output_url` plus the metadata receipt at the top level.
+    const { client } = stubClient(() =>
+      jsonResponse({
+        job_id: 'pj-10',
+        status: 'completed',
+        output_url: 'https://example.com/out.json',
+        metadata: {
+          job_id: 'pj-10',
+          duration_ms: 1200,
+          page_count: 3,
+          billing: { service_tier: 'standard', total_credits: 3 },
+        },
+      }),
+    );
+    const job = await client.v2.parseJobs.get('pj-10');
+    expect(job.result).toBeNull();
+    const metadata = job.metadata as LandingAIADE.V2ParseMetadata;
+    expect(metadata.page_count).toBe(3);
+    expect(metadata.billing?.total_credits).toBe(3);
+    // The URL itself stays on the untyped envelope.
+    expect(job.raw['output_url']).toBe('https://example.com/out.json');
+  });
+
+  test('extractJobs.get surfaces the delivered-result metadata receipt', async () => {
+    const { client } = stubClient(() =>
+      jsonResponse({
+        job_id: 'ej-10',
+        status: 'completed',
+        output_url: 'https://example.com/out.json',
+        metadata: { job_id: 'ej-10', duration_ms: 7, billing: { total_credits: 2 } },
+      }),
+    );
+    const job = await client.v2.extractJobs.get('ej-10');
+    expect(job.result).toBeNull();
+    expect(job.metadata).toMatchObject({ job_id: 'ej-10', billing: { total_credits: 2 } });
+  });
+
+  test('an inline job reports a null metadata receipt (it lives on the result)', async () => {
+    const { client } = stubClient(() =>
+      jsonResponse({
+        job_id: 'ej-11',
+        status: 'completed',
+        result: {
+          extraction: {},
+          extraction_metadata: {},
+          markdown: '',
+          metadata: { job_id: 'ej-11', version: 'v', duration_ms: 1 },
+        },
+      }),
+    );
+    const job = await client.v2.extractJobs.get('ej-11');
+    expect(job.metadata).toBeNull();
+    expect((job.result as LandingAIADE.V2ExtractResult).metadata.job_id).toBe('ej-11');
+  });
+
   test('parseJobs.get maps a failed job error object', async () => {
     const { client } = stubClient(() =>
       jsonResponse({ job_id: 'pj-f', status: 'failed', error: { code: 'bad', message: 'nope' } }),

--- a/tests/contract/v2-smoke.test.ts
+++ b/tests/contract/v2-smoke.test.ts
@@ -67,6 +67,30 @@ describe('V2 contract (staging)', () => {
   );
 
   runIf(
+    'extractJobs job envelope carries the metadata receipt field',
+    async () => {
+      const client = new LandingAIADE({ apikey: apiKey!, environment: 'staging' });
+      const created = await client.v2.extractJobs.create({
+        schema: { type: 'object', properties: { revenue: { type: 'string' } } },
+        markdown: SAMPLE_MARKDOWN,
+      });
+      const done = await client.v2.extractJobs.wait(created.job_id, { timeout: 120_000 });
+      expect(done.is_terminal).toBe(true);
+      // Wired by the V2 spec-sync: the job envelope now carries a top-level
+      // `metadata` receipt alongside `output_url` when the result was delivered
+      // to an `output_save_url`. This job is inline, so the receipt is `null`
+      // and the metadata lives on the result instead.
+      expect(done.metadata === null || typeof done.metadata === 'object').toBe(true);
+      if (done.status === 'completed' && done.raw['output_url'] == null) {
+        expect(done.metadata).toBeNull();
+        const result = done.result as LandingAIADE.V2ExtractResult;
+        expect(typeof result.metadata.duration_ms).toBe('number');
+      }
+    },
+    180_000,
+  );
+
+  runIf(
     'parseJobs.list returns a normalized JobList against the new envelope',
     async () => {
       const client = new LandingAIADE({ apikey: apiKey!, environment: 'staging' });


### PR DESCRIPTION
Automated V2 spec-sync PR (`client.v2`).

- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference types.
- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff. The shipped-but-hand-maintained `/v2/workflow*` surface is not auto-wired, so workflow-only drift lands as a **mechanical-only PR** for a maintainer to reconcile by hand.

Gates (surface-lock, V2 contract tests, lint/build/test) must pass. The V2 ergonomic layer (unified Job, dual-host, schema coercion) is not in the spec, so when present the AI commit is a **draft a human finishes**. **Human review required before merge.**