### PR TITLE
spec-sync: track V2 spec drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ If some pages cannot be parsed, the request still succeeds (HTTP 206) and `metad
 
 The `document` parameter accepts an `fs.ReadStream`, a web `File`, a `fetch` `Response`, or the `toFile` helper; see [File Uploads](#file-uploads).
 
+The `model` parameter accepts a dated snapshot (`dpt-3-pro-20260710`), a `-latest` alias, or a bare family name (equivalent to that family's `-latest`). Two families are available: `dpt-3-pro` for highest quality, and `dpt-3-fast` for lower-latency parsing without vision-model captioning. It defaults to the latest DPT-3 Pro snapshot.
+
 ## Extract
 
 Use `client.v2.extract` to pull structured fields out of Markdown (typically from a parse response) using a schema. The `schema` parameter accepts a JSON Schema object or a JSON string. Provide exactly one Markdown source: `markdown` or `markdown_url`.
@@ -251,6 +253,8 @@ console.log(jobs.has_more);
 ```
 
 Extract jobs work the same way. The `create` method takes the same schema and Markdown arguments as `client.v2.extract`, plus `service_tier` and an optional `output_save_url` (a presigned URL the finished result is delivered to; the completed job then reports `output_url` in `Job.raw` instead of an inline `result`); it does not accept `saveTo`. The delivery moves the content, not the receipt: a completed job whose result went to an `output_save_url` still returns its metadata block — billing included — on `Job.metadata`, while an inline job leaves `Job.metadata` `null` and carries the same block inside `result.metadata`.
+
+A presigned `output_save_url` must stay valid until the job _completes_, not merely past submit. An already-expired URL — or one whose remaining validity is too short — is rejected at submit with a 422 that names the exact window required: at least 15 minutes for extract jobs, and for parse jobs 15 minutes plus 3 seconds per document page. Sign with credentials that outlive the expected job duration; a URL signed with temporary (assumed-role/session) credentials dies when that session expires, whatever its stated expiry.
 
 ```ts
 // A job whose result was delivered out-of-band still reports its metadata receipt

--- a/specs/_generated/v2-aide.d.ts
+++ b/specs/_generated/v2-aide.d.ts
@@ -162,8 +162,9 @@ export interface paths {
          * Run v2-workflow (sync)
          * @description Run synchronously and return the result inline.
          *
-         *     Accepts ``application/json`` (the request fields as the body) or
-         *     ``multipart/form-data`` (file fields are staged automatically).
+         *     Accepts ``application/json`` (the request fields as the body),
+         *     ``multipart/form-data`` (file fields are staged automatically),
+         *     or ``application/x-www-form-urlencoded`` (text fields only).
          *
          *     Returns **504** if the work does not finish within the wait
          *     window — long-running work belongs on the async ``POST
@@ -1067,7 +1068,7 @@ export interface operations {
                     options?: components["schemas"]["V2ExtractOptions"] | null;
                     /**
                      * Output Save Url
-                     * @description URL to save the result to — e.g. a presigned S3 PUT URL. Async jobs only. When set, the finished result is delivered (HTTP PUT) to this URL and the completed job reports ``output_url`` instead of an inline ``result``. Must be a public http(s) URL; private/loopback IPs are rejected at submit time.
+                     * @description URL to save the result to — e.g. a presigned S3 PUT URL. Async jobs only. When set, the finished result is delivered (HTTP PUT) to this URL and the completed job reports ``output_url`` instead of an inline ``result``. Must be a public http(s) URL; private/loopback IPs are rejected at submit time. A presigned URL must stay valid until the job COMPLETES, not just past submit — an already-expired presign, or one with less than 15 minutes of validity remaining (the default floor; the 422 names the exact window required), is rejected at submit. Sign with credentials that outlive the expected job duration: a URL signed with temporary (assumed-role/session) credentials dies when that session expires, regardless of the URL's stated expiry.
                      * @default null
                      */
                     output_save_url?: string | null;
@@ -1115,7 +1116,7 @@ export interface operations {
                     options?: components["schemas"]["V2ExtractOptions"] | null;
                     /**
                      * Output Save Url
-                     * @description URL to save the result to — e.g. a presigned S3 PUT URL. Async jobs only. When set, the finished result is delivered (HTTP PUT) to this URL and the completed job reports ``output_url`` instead of an inline ``result``. Must be a public http(s) URL; private/loopback IPs are rejected at submit time. JSON-serialized string in form data.
+                     * @description URL to save the result to — e.g. a presigned S3 PUT URL. Async jobs only. When set, the finished result is delivered (HTTP PUT) to this URL and the completed job reports ``output_url`` instead of an inline ``result``. Must be a public http(s) URL; private/loopback IPs are rejected at submit time. A presigned URL must stay valid until the job COMPLETES, not just past submit — an already-expired presign, or one with less than 15 minutes of validity remaining (the default floor; the 422 names the exact window required), is rejected at submit. Sign with credentials that outlive the expected job duration: a URL signed with temporary (assumed-role/session) credentials dies when that session expires, regardless of the URL's stated expiry. JSON-serialized string in form data.
                      * @default null
                      */
                     output_save_url?: string | null;
@@ -1404,7 +1405,7 @@ export interface operations {
                     document?: string;
                     /** @description A publicly accessible URL to the file to parse. The file must be a PDF or image; see the list of [supported file types](https://docs.landing.ai/dpt3/file-types). Provide either `document` or `document_url`, not both. */
                     document_url?: string;
-                    /** @description The DPT-3 model snapshot to use for this request. Accepts a dated snapshot (for example, `dpt-3-pro-20260710`), the `dpt-3-pro-latest` alias, or the bare `dpt-3-pro` family name (equivalent to `dpt-3-pro-latest`). Defaults to the latest DPT-3 Pro snapshot. */
+                    /** @description The DPT-3 model snapshot to use for this request. Accepts a dated snapshot (for example, `dpt-3-pro-20260710`), a `-latest` alias, or a bare family name (equivalent to that family's `-latest`). Two families are available: `dpt-3-pro` for highest quality, and `dpt-3-fast` for lower-latency parsing without vision-model captioning. Defaults to the latest DPT-3 Pro snapshot. */
                     model?: string;
                     /**
                      * ParseOptions
@@ -1547,7 +1548,7 @@ export interface operations {
                     document?: string;
                     /** @description A publicly accessible URL to the file to parse. The file must be a PDF or image; see the list of [supported file types](https://docs.landing.ai/dpt3/file-types). Provide either `document` or `document_url`, not both. */
                     document_url?: string;
-                    /** @description The DPT-3 model snapshot to use for this request. Accepts a dated snapshot (for example, `dpt-3-pro-20260710`), the `dpt-3-pro-latest` alias, or the bare `dpt-3-pro` family name (equivalent to `dpt-3-pro-latest`). Defaults to the latest DPT-3 Pro snapshot. */
+                    /** @description The DPT-3 model snapshot to use for this request. Accepts a dated snapshot (for example, `dpt-3-pro-20260710`), a `-latest` alias, or a bare family name (equivalent to that family's `-latest`). Two families are available: `dpt-3-pro` for highest quality, and `dpt-3-fast` for lower-latency parsing without vision-model captioning. Defaults to the latest DPT-3 Pro snapshot. */
                     model?: string;
                     /**
                      * ParseOptions
@@ -1579,7 +1580,7 @@ export interface operations {
                          */
                         password?: string | null;
                     };
-                    /** @description Public URL the full response is delivered to; the API response then carries ``output_url`` instead of inline data. */
+                    /** @description Public URL the full response is delivered to; the API response then carries ``output_url`` instead of inline data. A presigned URL must stay valid until the job COMPLETES, not just past submit: an already-expired URL, or one whose remaining validity is too short for the document's page count, is rejected at submit (422). By default the URL must retain at least 15 minutes of validity at submit, plus 3 seconds per document page; the 422 message names the exact window required. Sign with credentials that outlive the expected job duration — a URL signed with temporary (assumed-role/session) credentials dies when that session expires, regardless of the URL's stated expiry. */
                     output_save_url?: string;
                     /**
                      * @description Async service tier (``POST /jobs`` only). ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``.

--- a/specs/v2-aide.json
+++ b/specs/v2-aide.json
@@ -1469,7 +1469,7 @@
                       }
                     ],
                     "default": null,
-                    "description": "URL to save the result to — e.g. a presigned S3 PUT URL. Async jobs only. When set, the finished result is delivered (HTTP PUT) to this URL and the completed job reports ``output_url`` instead of an inline ``result``. Must be a public http(s) URL; private/loopback IPs are rejected at submit time.",
+                    "description": "URL to save the result to — e.g. a presigned S3 PUT URL. Async jobs only. When set, the finished result is delivered (HTTP PUT) to this URL and the completed job reports ``output_url`` instead of an inline ``result``. Must be a public http(s) URL; private/loopback IPs are rejected at submit time. A presigned URL must stay valid until the job COMPLETES, not just past submit — an already-expired presign, or one with less than 15 minutes of validity remaining (the default floor; the 422 names the exact window required), is rejected at submit. Sign with credentials that outlive the expected job duration: a URL signed with temporary (assumed-role/session) credentials dies when that session expires, regardless of the URL's stated expiry.",
                     "title": "Output Save Url"
                   },
                   "schema": {
@@ -1578,7 +1578,7 @@
                       }
                     ],
                     "default": null,
-                    "description": "URL to save the result to — e.g. a presigned S3 PUT URL. Async jobs only. When set, the finished result is delivered (HTTP PUT) to this URL and the completed job reports ``output_url`` instead of an inline ``result``. Must be a public http(s) URL; private/loopback IPs are rejected at submit time. JSON-serialized string in form data.",
+                    "description": "URL to save the result to — e.g. a presigned S3 PUT URL. Async jobs only. When set, the finished result is delivered (HTTP PUT) to this URL and the completed job reports ``output_url`` instead of an inline ``result``. Must be a public http(s) URL; private/loopback IPs are rejected at submit time. A presigned URL must stay valid until the job COMPLETES, not just past submit — an already-expired presign, or one with less than 15 minutes of validity remaining (the default floor; the 422 names the exact window required), is rejected at submit. Sign with credentials that outlive the expected job duration: a URL signed with temporary (assumed-role/session) credentials dies when that session expires, regardless of the URL's stated expiry. JSON-serialized string in form data.",
                     "title": "Output Save Url"
                   },
                   "schema": {
@@ -2017,7 +2017,7 @@
                     "type": "string"
                   },
                   "model": {
-                    "description": "The DPT-3 model snapshot to use for this request. Accepts a dated snapshot (for example, `dpt-3-pro-20260710`), the `dpt-3-pro-latest` alias, or the bare `dpt-3-pro` family name (equivalent to `dpt-3-pro-latest`). Defaults to the latest DPT-3 Pro snapshot.",
+                    "description": "The DPT-3 model snapshot to use for this request. Accepts a dated snapshot (for example, `dpt-3-pro-20260710`), a `-latest` alias, or a bare family name (equivalent to that family's `-latest`). Two families are available: `dpt-3-pro` for highest quality, and `dpt-3-fast` for lower-latency parsing without vision-model captioning. Defaults to the latest DPT-3 Pro snapshot.",
                     "type": "string"
                   },
                   "options": {
@@ -2276,7 +2276,7 @@
                     "type": "string"
                   },
                   "model": {
-                    "description": "The DPT-3 model snapshot to use for this request. Accepts a dated snapshot (for example, `dpt-3-pro-20260710`), the `dpt-3-pro-latest` alias, or the bare `dpt-3-pro` family name (equivalent to `dpt-3-pro-latest`). Defaults to the latest DPT-3 Pro snapshot.",
+                    "description": "The DPT-3 model snapshot to use for this request. Accepts a dated snapshot (for example, `dpt-3-pro-20260710`), a `-latest` alias, or a bare family name (equivalent to that family's `-latest`). Two families are available: `dpt-3-pro` for highest quality, and `dpt-3-fast` for lower-latency parsing without vision-model captioning. Defaults to the latest DPT-3 Pro snapshot.",
                     "type": "string"
                   },
                   "options": {
@@ -2331,7 +2331,7 @@
                     "type": "object"
                   },
                   "output_save_url": {
-                    "description": "Public URL the full response is delivered to; the API response then carries ``output_url`` instead of inline data.",
+                    "description": "Public URL the full response is delivered to; the API response then carries ``output_url`` instead of inline data. A presigned URL must stay valid until the job COMPLETES, not just past submit: an already-expired URL, or one whose remaining validity is too short for the document's page count, is rejected at submit (422). By default the URL must retain at least 15 minutes of validity at submit, plus 3 seconds per document page; the 422 message names the exact window required. Sign with credentials that outlive the expected job duration — a URL signed with temporary (assumed-role/session) credentials dies when that session expires, regardless of the URL's stated expiry.",
                     "type": "string"
                   },
                   "service_tier": {
@@ -2535,7 +2535,7 @@
     },
     "/v2/workflow": {
       "post": {
-        "description": "Run synchronously and return the result inline.\n\nAccepts ``application/json`` (the request fields as the body) or\n``multipart/form-data`` (file fields are staged automatically).\n\nReturns **504** if the work does not finish within the wait\nwindow — long-running work belongs on the async ``POST\n{path}/jobs`` route, which returns 202 immediately and is polled\nvia ``GET {path}/jobs/{job_id}``. On a 504 the workflow is\nCANCELLED (a sync caller can never collect the result); a retry\nstarts the work over as a fresh job.",
+        "description": "Run synchronously and return the result inline.\n\nAccepts ``application/json`` (the request fields as the body),\n``multipart/form-data`` (file fields are staged automatically),\nor ``application/x-www-form-urlencoded`` (text fields only).\n\nReturns **504** if the work does not finish within the wait\nwindow — long-running work belongs on the async ``POST\n{path}/jobs`` route, which returns 202 immediately and is polled\nvia ``GET {path}/jobs/{job_id}``. On a 504 the workflow is\nCANCELLED (a sync caller can never collect the result); a retry\nstarts the work over as a fresh job.",
         "operationId": "v2-workflow_run_sync",
         "requestBody": {
           "content": {

--- a/src/resources/v2/extract.ts
+++ b/src/resources/v2/extract.ts
@@ -51,6 +51,13 @@ export interface V2ExtractJobCreateParams extends V2ExtractParams {
    * `result` — the metadata receipt (billing included) still comes back on
    * `Job.metadata`. Must be a public http(s) URL; private/loopback IPs are
    * rejected at submit time.
+   *
+   * A presigned URL must stay valid until the job *completes*, not just past
+   * submit: an already-expired presign, or one with less than 15 minutes of
+   * validity remaining (the default floor — the 422 names the exact window
+   * required), is rejected at submit. Sign with credentials that outlive the
+   * expected job duration; a URL signed with temporary (assumed-role/session)
+   * credentials dies when that session expires, whatever its stated expiry.
    */
   output_save_url?: string | null;
 }

--- a/src/resources/v2/parse.ts
+++ b/src/resources/v2/parse.ts
@@ -21,7 +21,13 @@ export interface V2ParseParams {
   /** URL to the file to be parsed. Provide either this or `document`. */
   document_url?: string | null;
 
-  /** The version of the model to use for parsing. */
+  /**
+   * The DPT-3 model snapshot to use for parsing. Accepts a dated snapshot (for
+   * example, `dpt-3-pro-20260710`), a `-latest` alias, or a bare family name
+   * (equivalent to that family's `-latest`). Two families are available:
+   * `dpt-3-pro` for highest quality, and `dpt-3-fast` for lower-latency parsing
+   * without vision-model captioning. Defaults to the latest DPT-3 Pro snapshot.
+   */
   model?: string | null;
 
   /** Additional parsing options. Sent to the server as a JSON-encoded form field. */
@@ -40,6 +46,15 @@ export interface V2ParseJobCreateParams extends V2ParseParams {
    * saved to instead of being returned in the job result. The completed job
    * then reports `output_url` (in `Job.raw`) instead of an inline `result`, and
    * the parse metadata receipt (billing included) on `Job.metadata`.
+   *
+   * A presigned URL must stay valid until the job *completes*, not just past
+   * submit: an already-expired URL, or one whose remaining validity is too
+   * short for the document's page count, is rejected at submit (422). By
+   * default the URL must retain at least 15 minutes of validity at submit, plus
+   * 3 seconds per document page; the 422 message names the exact window
+   * required. Sign with credentials that outlive the expected job duration; a
+   * URL signed with temporary (assumed-role/session) credentials dies when that
+   * session expires, whatever its stated expiry.
    */
   output_save_url?: string | null;
 


### PR DESCRIPTION
Automated V2 spec-sync PR (`client.v2`).

- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference types.
- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff. The shipped-but-hand-maintained `/v2/workflow*` surface is not auto-wired, so workflow-only drift lands as a **mechanical-only PR** for a maintainer to reconcile by hand.

Gates (surface-lock, V2 contract tests, lint/build/test) must pass. The V2 ergonomic layer (unified Job, dual-host, schema coercion) is not in the spec, so when present the AI commit is a **draft a human finishes**. **Human review required before merge.**

<!-- what-changed:start -->
## What changed
_AI-generated from the PR diff — verify against the actual changes._

### `client.v2.parse` / `client.v2.parseJobs`
- **`model` param**: docs clarified — accepts a dated snapshot, a `-latest` alias, or a bare family name; two families now documented: `dpt-3-pro` (highest quality) and `dpt-3-fast` (lower-latency, no vision captioning). Defaults to latest DPT-3 Pro. No type/signature change.
- **`output_save_url` param** (`parseJobs.create`): documentation-only addition — presigned URL must remain valid until job completion (≥15 min at submit + 3s/page), or submit is rejected with 422. No behavioral/type change to the SDK surface itself (server-side validation).

### `client.v2.extractJobs`
- **`output_save_url` param** (`extractJobs.create`): documentation-only addition — presigned URL must remain valid until job completion (≥15 min at submit), or submit is rejected with 422.

### README
- Expanded guidance on `model` (parse) and `output_save_url` (parse/extract jobs) validity-window requirements; no new endpoints or params.

### Other
- Spec snapshot for `/v2/workflow` (sync run) updated to note support for `application/x-www-form-urlencoded` in addition to JSON/multipart, but no `client.v2.workflow` / `client.v2.workflowJobs` surface changes are part of this PR.
<!-- what-changed:end -->