### PR TITLE
feat: add V2 production e2e to the release gate

### DIFF
--- a/.github/workflows/e2e-production.yml
+++ b/.github/workflows/e2e-production.yml
@@ -1,17 +1,19 @@
-# V1 end-to-end tests against the LIVE PRODUCTION API (api.va.landing.ai).
+# V1 + V2 end-to-end tests against the LIVE PRODUCTION API. V1 targets api.va.landing.ai
+# and V2 (`client.v2`) targets api.ade.landing.ai; the same key authenticates both hosts.
 #
 # Unlike the staging contract gate in pr-gates.yml, this is NOT wired to pull requests.
 # It runs in exactly two places:
-#   1. manually — Actions -> "E2E Production (V1)" -> Run workflow;
+#   1. manually — Actions -> "E2E Production" -> Run workflow;
 #   2. as the pre-tag gate in release.yml, which calls this workflow via `workflow_call`
 #      and refuses to stamp/commit/tag if it goes red.
 #
 # COST: every run exercises the full V1 surface (parse, extract, build-schema, classify,
-# section, split, and both job types) against production, so it spends real inference
-# credits and leaves real job records in the production org — roughly 8 inference calls
-# on a 2-page PDF. That is the deliberate price of gating releases on the real API; do
-# not add this to a per-PR trigger.
-name: E2E Production (V1)
+# section, split, both job types) plus the V2 surface (parse, extract, ground, both job
+# types — the soft-hidden build-schema is excluded), against production. It spends real
+# inference credits and leaves real job records in the production org — roughly a dozen
+# inference calls on a 2-page PDF. That is the deliberate price of gating releases on the
+# real API; do not add this to a per-PR trigger.
+name: E2E Production
 
 on:
   workflow_dispatch:
@@ -25,7 +27,7 @@ concurrency:
 
 jobs:
   e2e-production:
-    name: e2e (production V1)
+    name: e2e (production V1 + V2)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # Defense in depth: only main should reach the production key. release.yml runs on main
@@ -72,7 +74,9 @@ jobs:
       - name: Bootstrap
         run: ./scripts/bootstrap
 
-      - name: V1 e2e vs production
+      - name: V1 + V2 e2e vs production
         env:
           LANDINGAI_ADE_PRODUCTION_APIKEY: ${{ secrets.LANDINGAI_ADE_PRODUCTION_APIKEY }}
+        # jest.production.config.ts matches *-production.test.ts, so this runs both the V1
+        # and V2 production suites.
         run: yarn test:production

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@
 #
 # A maintainer runs this workflow (Actions -> Release -> Run workflow) and
 # picks the bump: patch / minor / major. The workflow then, in one shot:
-#   0. runs the V1 production e2e suite (.github/workflows/e2e-production.yml)
+#   0. runs the V1 + V2 production e2e suite (.github/workflows/e2e-production.yml)
 #      against the live API — nothing below runs if it goes red,
 #   1. computes the next version from the latest git tag,
 #   2. stamps it into package.json and src/version.ts,

--- a/tests/contract/v2-production.test.ts
+++ b/tests/contract/v2-production.test.ts
@@ -1,0 +1,116 @@
+import LandingAIADE, { toFile } from 'landingai-ade';
+import fs from 'fs';
+import path from 'path';
+
+// V2 (`client.v2`) production e2e — mirrors the staging V2 smoke (v2-smoke.test.ts) against the
+// LIVE PRODUCTION API host api.ade.landing.ai. Same file-selection and gating as
+// v1-production.test.ts: excluded from the default and `yarn test:contract` runs, picked up only by
+// `yarn test:production` (jest.production.config.ts matches *-production.test.ts), which
+// e2e-production.yml invokes on manual dispatch and as the release gate. Spends real credits. The
+// soft-hidden `client.v2.buildSchema` surface is intentionally not covered, matching the staging smoke.
+const apiKey = process.env['LANDINGAI_ADE_PRODUCTION_APIKEY'];
+const runIf = apiKey ? test : test.skip;
+
+const SAMPLE_MARKDOWN = '# Acme Inc. — Q1 Report\n\nTotal revenue for the quarter was **$1,250,000**.\n';
+const SAMPLE_PDF = path.join(__dirname, 'sample.pdf');
+const pdfBytes = fs.readFileSync(SAMPLE_PDF);
+
+// `environment: 'production'` routes V2 to api.ade.landing.ai; the same key authenticates both hosts.
+const newClient = () => new LandingAIADE({ apikey: apiKey!, environment: 'production' });
+
+describe('V2 e2e (production)', () => {
+  runIf(
+    'extract (sync) returns a structured extraction with range_units metadata',
+    async () => {
+      const res = await newClient().v2.extract({
+        schema: { type: 'object', properties: { revenue: { type: 'string' } } },
+        markdown: SAMPLE_MARKDOWN,
+      });
+      expect(res.extraction).toBeDefined();
+      // Ranges are declared in code-point units, and `version` was renamed to `model_version`.
+      expect(res.metadata.range_units).toBe('unicode_codepoints');
+      expect(typeof res.metadata.model_version).toBe('string');
+    },
+    60_000,
+  );
+
+  runIf(
+    'ground (sync) resolves extracted fields to structure blocks',
+    async () => {
+      // Ground is a pure, stateless join of an extraction's `{value, ranges}` leaves against the
+      // `grounding.range` on each `structure` block, so a self-consistent synthetic pair exercises
+      // the route directly (parse and extract are covered by the other tests). The single field's
+      // range overlaps `text-1`.
+      const box = { xmin: 0.1, ymin: 0.12, xmax: 0.42, ymax: 0.15 };
+      const res = await newClient().v2.ground({
+        extraction_metadata: {
+          invoice_number: { value: 'INV-042', ranges: [{ start: 13, end: 31 }] },
+        },
+        structure: {
+          type: 'document',
+          children: [
+            {
+              type: 'page',
+              page: 1,
+              children: [
+                { type: 'text', id: 'text-1', grounding: { page: 1, range: { start: 13, end: 31 }, box } },
+              ],
+            },
+          ],
+        },
+      });
+      expect(res.grounding).toBeDefined();
+      expect(res.grounding['invoice_number']).toBeDefined();
+      expect(typeof res.metadata.job_id).toBe('string');
+    },
+    60_000,
+  );
+
+  runIf(
+    'extractJobs create → wait resolves to a terminal inline result',
+    async () => {
+      const client = newClient();
+      const created = await client.v2.extractJobs.create({
+        schema: { type: 'object', properties: { revenue: { type: 'string' } } },
+        markdown: SAMPLE_MARKDOWN,
+      });
+      const done = await client.v2.extractJobs.wait(created.job_id, { timeout: 120_000 });
+      expect(done.is_terminal).toBe(true);
+      // The job envelope carries a top-level `metadata` receipt only when the result was
+      // delivered to an `output_save_url`. This job is inline, so the receipt is `null` and the
+      // metadata lives on the result instead.
+      expect(done.metadata === null || typeof done.metadata === 'object').toBe(true);
+      if (done.status === 'completed' && done.raw['output_url'] == null) {
+        expect(done.metadata).toBeNull();
+        const result = done.result as LandingAIADE.V2ExtractResult;
+        expect(typeof result.metadata.duration_ms).toBe('number');
+      }
+    },
+    180_000,
+  );
+
+  runIf(
+    'parseJobs create → wait, then list returns a non-empty normalized JobList',
+    async () => {
+      const client = newClient();
+      // Complete a real parse job first so the list assertion below is non-vacuous: an empty page
+      // would let a broken list/normalizer pass this release gate. This also gives the suite its
+      // only real parse (the staging smoke never parses a document).
+      const created = await client.v2.parseJobs.create({
+        document: await toFile(pdfBytes, 'sample.pdf', { type: 'application/pdf' }),
+      });
+      const done = await client.v2.parseJobs.wait(created.job_id, { timeout: 180_000 });
+      expect(done.is_terminal).toBe(true);
+
+      const list = await client.v2.parseJobs.list({ page: 0, page_size: 10 });
+      expect(list.jobs.length).toBeGreaterThan(0);
+      for (const job of list.jobs) {
+        expect(typeof job.job_id).toBe('string');
+        // The list envelope emits ISO-8601 timestamps; the normalizer maps them to `Date`
+        // (or `null` when absent).
+        expect(job.created_at === null || job.created_at instanceof Date).toBe(true);
+      }
+    },
+    240_000,
+  );
+});


### PR DESCRIPTION
Extends the production e2e gate to cover the V2 surface (`client.v2`), which previously had only staging smoke coverage. Follow-up to #107 (V1 production e2e). Mirrors the same change in ade-python.

- `tests/contract/v2-production.test.ts` — mirrors the staging V2 smoke against the live production V2 host (`api.ade.landing.ai`): `extract` (sync), `ground`, `extractJobs`, and a `parseJobs` create→wait→list. The list check is **non-vacuous** — it completes a real parse job first, then asserts a non-empty normalized `JobList` (this also gives the suite its only real parse, which the staging smoke lacked). The soft-hidden `client.v2.buildSchema` is excluded.
- No new secret / no new job: `jest.production.config.ts` matches `*-production.test.ts`, so `yarn test:production` runs both suites and V2 gates release automatically. `production-e2e` env + `LANDINGAI_ADE_PRODUCTION_APIKEY` are reused (same key authenticates both hosts).
- Renamed the workflow **E2E Production (V1) → E2E Production**.

**Trade-off (as discussed):** V2 now shares the release gate, so a V2 production issue can block a V1 release, and per-release credit spend roughly doubles.

Verified locally: tsc + eslint + prettier clean, `jest.production.config.ts` selects both V1 and V2 suites, V2 skips cleanly (4 tests) with no key. Not run against live production (needs the key + spends credits).