### PR TITLE
spec-sync(v2): add per-word grounding confidence for dpt-3-fast

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,17 +98,39 @@ const fromUrl = await client.v2.parse({ document_url: 'https://example.com/file.
 
 The response is a `V2ParseResponse`:
 
-| Field       | Description                                                                                                                                                                                                                                                         |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `markdown`  | The full document as one Markdown string, in reading order.                                                                                                                                                                                                         |
-| `structure` | A typed tree (`document` → pages → elements). Each node carries a `grounding` object — its page, its `{ start, end }` range into `markdown`, and a bounding box in normalized (`0`–`1`) page coordinates; leaf elements also carry fine-grained `atomic_grounding`. |
-| `metadata`  | Processing details: `page_count`, `failed_pages`, `range_units` (offsets are Unicode code points), `duration_ms`, and `billing` (credits used).                                                                                                                     |
+| Field       | Description                                                                                                                                                                                                                                                                                                       |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `markdown`  | The full document as one Markdown string, in reading order.                                                                                                                                                                                                                                                       |
+| `structure` | A typed tree (`document` → pages → elements). Each node carries a `grounding` object — its page, its `{ start, end }` range into `markdown`, and a bounding box in normalized (`0`–`1`) page coordinates; leaf elements also carry fine-grained `atomic_grounding`, whose entries add a per-segment `confidence`. |
+| `metadata`  | Processing details: `page_count`, `failed_pages`, `range_units` (offsets are Unicode code points), `duration_ms`, and `billing` (credits used).                                                                                                                                                                   |
 
 If some pages cannot be parsed, the request still succeeds (HTTP 206) and `metadata.failed_pages` lists the pages that failed. If a synchronous parse times out, the client throws `V2SyncTimeoutError`; use [jobs](#process-large-documents-asynchronously-jobs) instead.
 
 The `document` parameter accepts an `fs.ReadStream`, a web `File`, a `fetch` `Response`, or the `toFile` helper; see [File Uploads](#file-uploads).
 
 The `model` parameter accepts a dated snapshot (`dpt-3-pro-20260710`), a `-latest` alias, or a bare family name (equivalent to that family's `-latest`). Two families are available: `dpt-3-pro` for highest quality, and `dpt-3-fast` for lower-latency parsing without vision-model captioning. It defaults to the latest DPT-3 Pro snapshot.
+
+### Grounding confidence
+
+`atomic_grounding` reports segments at whichever granularity the model reads at: one entry per visual line for `dpt-3-pro`, and one per **word** for `dpt-3-fast` (including the words inside table cells). Word entries also carry a `confidence` in `[0, 1]` — the lowest per-character OCR confidence in that word, so a word is only as trustworthy as its weakest character. It is `null` on node-level `grounding` and on line-granularity models.
+
+```ts
+const parsed = await client.v2.parse({
+  document: fs.createReadStream('path/to/file.pdf'),
+  model: 'dpt-3-fast',
+});
+
+// Flag the low-confidence words for human review.
+for (const page of parsed.structure?.children ?? []) {
+  for (const element of page.children ?? []) {
+    for (const word of element.atomic_grounding ?? []) {
+      if (word.confidence !== null && word.confidence < 0.5) {
+        console.log(`page ${word.page} @ ${word.range.start}-${word.range.end}: ${word.confidence}`);
+      }
+    }
+  }
+}
+```
 
 ## Extract
 

--- a/api.md
+++ b/api.md
@@ -57,6 +57,8 @@ Methods:
 
 The `client.v2` sub-client targets LandingAI's next-generation ADE gateway on its own host (`api.ade.[env].landing.ai`), separate from the V1 host (`api.va.[env].landing.ai`). It is **additive** — `client.v2.*` is a separate surface from the top-level `client.*` (V1) methods above, and using it does not change any V1 behavior.
 
+Every node in a parse `structure` tree carries a <a href="./src/resources/v2/types.ts">`V2Grounding`</a> (`{page, range, box, confidence}`). `confidence` is populated only on word-granularity `atomic_grounding` entries (`dpt-3-fast`), where it is the lowest per-character OCR confidence in the word; it is `null` on node-level grounding and on line-granularity models.
+
 `client.v2.parseJobs` and `client.v2.extractJobs` both return a single, unified <a href="./src/resources/v2/types.ts">`Job`</a> shape even though the underlying parse/extract job envelopes differ upstream — `Job.raw` retains the full original envelope as an escape hatch. `Job.metadata` carries the envelope's top-level metadata receipt (a <a href="./src/resources/v2/types.ts">`V2ParseMetadata`</a> for parse jobs), returned alongside `raw.output_url` when a job created with `output_save_url` completes; it is `null` for inline jobs, whose metadata lives on `Job.result`.
 
 Types:
@@ -67,6 +69,8 @@ Types:
 - <code><a href="./src/resources/v2/types.ts">JobStatus</a></code>
 - <code><a href="./src/resources/v2/types.ts">V2ParseResponse</a></code>
 - <code><a href="./src/resources/v2/types.ts">V2ParseMetadata</a></code>
+- <code><a href="./src/resources/v2/types.ts">V2Grounding</a></code>
+- <code><a href="./src/resources/v2/types.ts">V2GroundingBox</a></code>
 - <code><a href="./src/resources/v2/types.ts">V2ExtractResult</a></code>
 - <code><a href="./src/resources/v2/types.ts">V2BuildSchemaResult</a></code>
 - <code><a href="./src/resources/v2/types.ts">V2BuildSchemaMetadata</a></code>

--- a/specs/_generated/v2-aide.d.ts
+++ b/specs/_generated/v2-aide.d.ts
@@ -4,6 +4,70 @@
  */
 
 export interface paths {
+    "/v1/extract/build-schema": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * ADE Extract
+         * @description Generate or edit a JSON Schema for extraction from one or more source Markdown documents and/or a natural-language prompt. v1-compatible wire, running the same schema-build engine as `/v2/extract/build-schema`. The one difference: this route accepts `model` and echoes it back as `metadata.version`. Schema generation is version-free, so `model` does NOT select a model and does not change the generated schema. Runs synchronously and returns the result inline.
+         */
+        post: operations["v1-build-schema_run_sync"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/extract/build-schema/jobs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * ADE List Extract Jobs
+         * @description List your Extract jobs, newest first.
+         */
+        get: operations["v1-build-schema_list_jobs"];
+        put?: never;
+        /**
+         * ADE Extract Jobs
+         * @description Generate or edit a JSON Schema for extraction from one or more source Markdown documents and/or a natural-language prompt. v1-compatible wire, running the same schema-build engine as `/v2/extract/build-schema`. The one difference: this route accepts `model` and echoes it back as `metadata.version`. Schema generation is version-free, so `model` does NOT select a model and does not change the generated schema. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.
+         */
+        post: operations["v1-build-schema_create_job"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/extract/build-schema/jobs/{job_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * ADE Get Extract Jobs
+         * @description Get the status of an async Extract job, including its result once the job has completed.
+         */
+        get: operations["v1-build-schema_get_job"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v2/extract": {
         parameters: {
             query?: never;
@@ -327,7 +391,7 @@ export interface components {
         Element: {
             /**
              * Atomic Grounding
-             * @description Fine-grained grounding segments at the model's current granularity (visual lines today; finer in future versions, same schema). Present only on leaf elements — every type except `table`. `[]` only when segments are structurally impossible: `table_cell` (a cell has no finer granularity than itself) and elements whose markdown is suppressed via `blocks.<type>.markdown=false`. Any other leaf the model could not segment finer carries a single entry covering the element's full range and box. Omitted entirely when `options.atomic_grounding` is `false`.
+             * @description Fine-grained grounding segments, at whichever granularity the model reads at: one entry per visual line for `dpt-3-pro`, one per **word** — each with its `confidence` — for `dpt-3-fast`, including the words inside table cells. Present only on leaf elements — every type except `table`. `[]` in three cases: an element whose markdown is suppressed via `blocks.<type>.markdown=false`; a `table_cell` on a line-granularity model (a cell has no finer granularity than itself there); and a `table_cell` on a word-granularity model whose words cannot be located in the rendered cell text — a `|` escaped on the way into a pipe table, or a character escaped on the way into an HTML table — where the segments are dropped rather than risk reporting offsets that point at the wrong characters. Any other leaf the model could not segment finer carries a single entry covering the element's full range and box. Omitted entirely when `options.atomic_grounding` is `false`.
              * @default null
              */
             atomic_grounding: components["schemas"]["Grounding"][] | null;
@@ -407,6 +471,12 @@ export interface components {
         Grounding: {
             /** @description Bounding box in normalized page coordinates (`0`–`1` fractions of page width/height, at most 8 decimal places). A page node's box is always the full page `{0, 0, 1, 1}`. */
             box: components["schemas"]["Box"];
+            /**
+             * Confidence
+             * @description How sure the model is of the text in this segment, in `[0, 1]`. Present only on word-granularity `atomic_grounding` entries (`dpt-3-fast`), where it is the lowest per-character OCR confidence in the word — so a word is only as trustworthy as its weakest character. Omitted on node-level grounding and on models that ground at line granularity.
+             * @default null
+             */
+            confidence: number | null;
             /**
              * Page
              * @description 1-indexed page number this grounding is on. On a page node, the page's own number.
@@ -831,6 +901,325 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    "v1-build-schema_run_sync": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Markdown Urls
+                     * @description URLs to Markdown files to analyze for schema generation.
+                     * @default null
+                     */
+                    markdown_urls?: string[] | null;
+                    /**
+                     * Markdowns
+                     * @description Markdown files or inline content strings to analyze for schema generation. Multiple documents can be provided for better schema coverage.
+                     * @default null
+                     */
+                    markdowns?: string[] | null;
+                    /**
+                     * Model
+                     * @description Accepted for v1 wire compatibility and echoed back as `metadata.version`. Schema generation is version-free — this value does NOT select a model and does not change the generated schema. Bounded to 256 characters; blank values are treated as absent.
+                     * @default null
+                     */
+                    model?: string | null;
+                    /**
+                     * Prompt
+                     * @description Instructions for how to generate or modify the schema.
+                     * @default null
+                     */
+                    prompt?: string | null;
+                    /**
+                     * Schema
+                     * @description Existing JSON schema to iterate on or refine.
+                     * @default null
+                     */
+                    schema?: string | null;
+                };
+                "multipart/form-data": {
+                    /**
+                     * Markdown Urls
+                     * @description URLs to Markdown files to analyze for schema generation. JSON-serialized string in form data.
+                     * @default null
+                     */
+                    markdown_urls?: string[] | null;
+                    /** @description Repeat the field for each file upload. */
+                    markdowns?: (string)[];
+                    /**
+                     * Model
+                     * @description Accepted for v1 wire compatibility and echoed back as `metadata.version`. Schema generation is version-free — this value does NOT select a model and does not change the generated schema. Bounded to 256 characters; blank values are treated as absent. JSON-serialized string in form data.
+                     * @default null
+                     */
+                    model?: string | null;
+                    /**
+                     * Prompt
+                     * @description Instructions for how to generate or modify the schema. JSON-serialized string in form data.
+                     * @default null
+                     */
+                    prompt?: string | null;
+                    /**
+                     * Schema
+                     * @description Existing JSON schema to iterate on or refine. JSON-serialized string in form data.
+                     * @default null
+                     */
+                    schema?: string | null;
+                };
+            };
+        };
+        responses: {
+            /** @description v1-build-schema result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * Extraction Schema
+                         * @description The generated JSON schema as a string.
+                         */
+                        extraction_schema: string;
+                        /** @description The metadata for the schema generation process. */
+                        metadata: components["schemas"]["V2BuildSchemaMetadata"];
+                    };
+                };
+            };
+            /** @description Request validation failed. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    "v1-build-schema_list_jobs": {
+        parameters: {
+            query?: {
+                /** @description Page number (0-indexed). */
+                page?: number;
+                /** @description Number of items per page. */
+                page_size?: number;
+                /** @description Filter by job status. */
+                status?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The caller's jobs, newest first */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        has_more?: boolean;
+                        jobs?: {
+                            completed_at?: string | null;
+                            created_at?: string | null;
+                            failure_reason?: string | null;
+                            /** @description The unique identifier for this v1-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
+                            job_id?: string;
+                            model_version?: string | null;
+                            /** @enum {string} */
+                            status?: "pending" | "processing" | "completed" | "failed";
+                        }[];
+                        page?: number;
+                        page_size?: number;
+                    };
+                };
+            };
+            /** @description Request validation failed. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    "v1-build-schema_create_job": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Markdown Urls
+                     * @description URLs to Markdown files to analyze for schema generation.
+                     * @default null
+                     */
+                    markdown_urls?: string[] | null;
+                    /**
+                     * Markdowns
+                     * @description Markdown files or inline content strings to analyze for schema generation. Multiple documents can be provided for better schema coverage.
+                     * @default null
+                     */
+                    markdowns?: string[] | null;
+                    /**
+                     * Model
+                     * @description Accepted for v1 wire compatibility and echoed back as `metadata.version`. Schema generation is version-free — this value does NOT select a model and does not change the generated schema. Bounded to 256 characters; blank values are treated as absent.
+                     * @default null
+                     */
+                    model?: string | null;
+                    /**
+                     * Prompt
+                     * @description Instructions for how to generate or modify the schema.
+                     * @default null
+                     */
+                    prompt?: string | null;
+                    /**
+                     * Schema
+                     * @description Existing JSON schema to iterate on or refine.
+                     * @default null
+                     */
+                    schema?: string | null;
+                    /** @description Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``. */
+                    service_tier?: ("standard" | "priority") | null;
+                };
+                "multipart/form-data": {
+                    /**
+                     * Markdown Urls
+                     * @description URLs to Markdown files to analyze for schema generation. JSON-serialized string in form data.
+                     * @default null
+                     */
+                    markdown_urls?: string[] | null;
+                    /** @description Repeat the field for each file upload. */
+                    markdowns?: (string)[];
+                    /**
+                     * Model
+                     * @description Accepted for v1 wire compatibility and echoed back as `metadata.version`. Schema generation is version-free — this value does NOT select a model and does not change the generated schema. Bounded to 256 characters; blank values are treated as absent. JSON-serialized string in form data.
+                     * @default null
+                     */
+                    model?: string | null;
+                    /**
+                     * Prompt
+                     * @description Instructions for how to generate or modify the schema. JSON-serialized string in form data.
+                     * @default null
+                     */
+                    prompt?: string | null;
+                    /**
+                     * Schema
+                     * @description Existing JSON schema to iterate on or refine. JSON-serialized string in form data.
+                     * @default null
+                     */
+                    schema?: string | null;
+                    /** @description Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``. */
+                    service_tier?: ("standard" | "priority") | null;
+                };
+            };
+        };
+        responses: {
+            /** @description Job created */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        created_at?: string | null;
+                        /** @description The unique identifier for this v1-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
+                        job_id?: string;
+                        /** @enum {string} */
+                        status?: "pending" | "processing" | "completed" | "failed";
+                    };
+                };
+            };
+            /** @description Request validation failed. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    "v1-build-schema_get_job": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The identifier of the job to retrieve, as returned by the create-job request. */
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Job status / result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Present once the job is terminal. */
+                        completed_at?: string;
+                        created_at?: string | null;
+                        /** @description Present once status is ``failed``. */
+                        error?: {
+                            /** @description Stable error code (``internal_error`` when unmapped). */
+                            code?: string;
+                            message?: string;
+                        };
+                        /** @description The unique identifier for this v1-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
+                        job_id?: string;
+                        /** @description Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``. */
+                        progress?: number;
+                        /** @description Present once status is ``completed``. */
+                        result?: {
+                            /**
+                             * Extraction Schema
+                             * @description The generated JSON schema as a string.
+                             */
+                            extraction_schema: string;
+                            /** @description The metadata for the schema generation process. */
+                            metadata: components["schemas"]["V2BuildSchemaMetadata"];
+                        } | null;
+                        /** @enum {string} */
+                        status?: "pending" | "processing" | "completed" | "failed";
+                    };
+                };
+            };
+            /** @description Not found (e.g. no such job). */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Request validation failed. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
     "v2-extract_run_sync": {
         parameters: {
             query?: never;

--- a/specs/v2-aide.json
+++ b/specs/v2-aide.json
@@ -148,7 +148,7 @@
               }
             ],
             "default": null,
-            "description": "Fine-grained grounding segments at the model's current granularity (visual lines today; finer in future versions, same schema). Present only on leaf elements — every type except `table`. `[]` only when segments are structurally impossible: `table_cell` (a cell has no finer granularity than itself) and elements whose markdown is suppressed via `blocks.<type>.markdown=false`. Any other leaf the model could not segment finer carries a single entry covering the element's full range and box. Omitted entirely when `options.atomic_grounding` is `false`.",
+            "description": "Fine-grained grounding segments, at whichever granularity the model reads at: one entry per visual line for `dpt-3-pro`, one per **word** — each with its `confidence` — for `dpt-3-fast`, including the words inside table cells. Present only on leaf elements — every type except `table`. `[]` in three cases: an element whose markdown is suppressed via `blocks.<type>.markdown=false`; a `table_cell` on a line-granularity model (a cell has no finer granularity than itself there); and a `table_cell` on a word-granularity model whose words cannot be located in the rendered cell text — a `|` escaped on the way into a pipe table, or a character escaped on the way into an HTML table — where the segments are dropped rather than risk reporting offsets that point at the wrong characters. Any other leaf the model could not segment finer carries a single entry covering the element's full range and box. Omitted entirely when `options.atomic_grounding` is `false`.",
             "title": "Atomic Grounding"
           },
           "children": {
@@ -302,6 +302,19 @@
           "box": {
             "$ref": "#/components/schemas/Box",
             "description": "Bounding box in normalized page coordinates (`0`–`1` fractions of page width/height, at most 8 decimal places). A page node's box is always the full page `{0, 0, 1, 1}`."
+          },
+          "confidence": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "How sure the model is of the text in this segment, in `[0, 1]`. Present only on word-granularity `atomic_grounding` entries (`dpt-3-fast`), where it is the lowest per-character OCR confidence in the word — so a word is only as trustworthy as its weakest character. Omitted on node-level grounding and on models that ground at line granularity.",
+            "title": "Confidence"
           },
           "page": {
             "description": "1-indexed page number this grounding is on. On a page node, the page's own number.",
@@ -1013,6 +1026,730 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/v1/extract/build-schema": {
+      "post": {
+        "description": "Generate or edit a JSON Schema for extraction from one or more source Markdown documents and/or a natural-language prompt. v1-compatible wire, running the same schema-build engine as `/v2/extract/build-schema`. The one difference: this route accepts `model` and echoes it back as `metadata.version`. Schema generation is version-free, so `model` does NOT select a model and does not change the generated schema. Runs synchronously and returns the result inline.",
+        "operationId": "v1-build-schema_run_sync",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to V1BuildSchemaOperationWorkflow — the ``/v1/extract/build-schema``\nrequest body, i.e. VTRA's ``/v1/ade/extract/build-schema`` wire.\n\nThe v2 request already mirrors VTRA's ``BuildSchemaRequest`` field-for-field\n(``markdowns`` / ``markdown_urls`` / ``prompt`` / ``schema``, plus the\nat-least-one-source validator), so this INHERITS all of it and adds back the\none field v2 deliberately dropped: ``model``.\n\nWhy the delta exists at all: v2 build-schema is intentionally version-free —\nschema generation runs on the build engine's default model, so v2 takes no\n``model`` and always answers ``metadata.version: null``. VTRA's v1 wire DOES\naccept ``model``, and a caller that sends it must not get a 422 for an unknown\nform field. So v1 accepts it and ECHOES it back in ``metadata.version``\n(``operations/v1_build_schema.py``'s ``map_result``).\n\nIt is an ECHO, not a selector — the value does not reach the engine and does\nnot change which model builds the schema. That is the honest shape: v1 and v2\ndrive the same ``extractor.build()``, and pretending ``model`` picks a version\nwould be a lie in the contract. Documented on the field below so a caller\nisn't misled into thinking they pinned anything.",
+                "properties": {
+                  "markdown_urls": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "URLs to Markdown files to analyze for schema generation.",
+                    "title": "Markdown Urls"
+                  },
+                  "markdowns": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Markdown files or inline content strings to analyze for schema generation. Multiple documents can be provided for better schema coverage.",
+                    "title": "Markdowns"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "maxLength": 256,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Accepted for v1 wire compatibility and echoed back as `metadata.version`. Schema generation is version-free — this value does NOT select a model and does not change the generated schema. Bounded to 256 characters; blank values are treated as absent.",
+                    "title": "Model"
+                  },
+                  "prompt": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Instructions for how to generate or modify the schema.",
+                    "title": "Prompt"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Existing JSON schema to iterate on or refine.",
+                    "title": "Schema"
+                  }
+                },
+                "title": "V1BuildSchemaRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "markdown_urls": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "URLs to Markdown files to analyze for schema generation. JSON-serialized string in form data.",
+                    "title": "Markdown Urls"
+                  },
+                  "markdowns": {
+                    "description": "Repeat the field for each file upload.",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "description": "Markdown files or inline content strings to analyze for schema generation. Multiple documents can be provided for better schema coverage.",
+                          "type": "string"
+                        },
+                        {
+                          "description": "File upload.",
+                          "format": "binary",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "type": "array"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "maxLength": 256,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Accepted for v1 wire compatibility and echoed back as `metadata.version`. Schema generation is version-free — this value does NOT select a model and does not change the generated schema. Bounded to 256 characters; blank values are treated as absent. JSON-serialized string in form data.",
+                    "title": "Model"
+                  },
+                  "prompt": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Instructions for how to generate or modify the schema. JSON-serialized string in form data.",
+                    "title": "Prompt"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Existing JSON schema to iterate on or refine. JSON-serialized string in form data.",
+                    "title": "Schema"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Result returned by V2BuildSchemaOperationWorkflow — the\n``/v2/extract/build-schema`` response body (VTRA ``BuildSchemaResponse``).\n\n``extraction_schema`` is the generated JSON Schema serialized as a STRING\n(VTRA parity — the v1 field is a string, not an object).",
+                  "properties": {
+                    "extraction_schema": {
+                      "description": "The generated JSON schema as a string.",
+                      "title": "Extraction Schema",
+                      "type": "string"
+                    },
+                    "metadata": {
+                      "$ref": "#/components/schemas/V2BuildSchemaMetadata",
+                      "description": "The metadata for the schema generation process."
+                    }
+                  },
+                  "required": [
+                    "extraction_schema",
+                    "metadata"
+                  ],
+                  "title": "V2BuildSchemaResponse",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "v1-build-schema result"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Extract",
+        "tags": [
+          "Extract"
+        ]
+      }
+    },
+    "/v1/extract/build-schema/jobs": {
+      "get": {
+        "description": "List your Extract jobs, newest first.",
+        "operationId": "v1-build-schema_list_jobs",
+        "parameters": [
+          {
+            "description": "Page number (0-indexed).",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Page number (0-indexed).",
+              "minimum": 0,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of items per page.",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Number of items per page.",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter by job status.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by job status.",
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "has_more": {
+                      "type": "boolean"
+                    },
+                    "jobs": {
+                      "items": {
+                        "properties": {
+                          "completed_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "created_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "failure_reason": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "job_id": {
+                            "description": "The unique identifier for this v1-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                            "type": "string"
+                          },
+                          "model_version": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "status": {
+                            "enum": [
+                              "pending",
+                              "processing",
+                              "completed",
+                              "failed"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "page_size": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The caller's jobs, newest first"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE List Extract Jobs",
+        "tags": [
+          "Extract"
+        ]
+      },
+      "post": {
+        "description": "Generate or edit a JSON Schema for extraction from one or more source Markdown documents and/or a natural-language prompt. v1-compatible wire, running the same schema-build engine as `/v2/extract/build-schema`. The one difference: this route accepts `model` and echoes it back as `metadata.version`. Schema generation is version-free, so `model` does NOT select a model and does not change the generated schema. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.",
+        "operationId": "v1-build-schema_create_job",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to V1BuildSchemaOperationWorkflow — the ``/v1/extract/build-schema``\nrequest body, i.e. VTRA's ``/v1/ade/extract/build-schema`` wire.\n\nThe v2 request already mirrors VTRA's ``BuildSchemaRequest`` field-for-field\n(``markdowns`` / ``markdown_urls`` / ``prompt`` / ``schema``, plus the\nat-least-one-source validator), so this INHERITS all of it and adds back the\none field v2 deliberately dropped: ``model``.\n\nWhy the delta exists at all: v2 build-schema is intentionally version-free —\nschema generation runs on the build engine's default model, so v2 takes no\n``model`` and always answers ``metadata.version: null``. VTRA's v1 wire DOES\naccept ``model``, and a caller that sends it must not get a 422 for an unknown\nform field. So v1 accepts it and ECHOES it back in ``metadata.version``\n(``operations/v1_build_schema.py``'s ``map_result``).\n\nIt is an ECHO, not a selector — the value does not reach the engine and does\nnot change which model builds the schema. That is the honest shape: v1 and v2\ndrive the same ``extractor.build()``, and pretending ``model`` picks a version\nwould be a lie in the contract. Documented on the field below so a caller\nisn't misled into thinking they pinned anything.",
+                "properties": {
+                  "markdown_urls": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "URLs to Markdown files to analyze for schema generation.",
+                    "title": "Markdown Urls"
+                  },
+                  "markdowns": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Markdown files or inline content strings to analyze for schema generation. Multiple documents can be provided for better schema coverage.",
+                    "title": "Markdowns"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "maxLength": 256,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Accepted for v1 wire compatibility and echoed back as `metadata.version`. Schema generation is version-free — this value does NOT select a model and does not change the generated schema. Bounded to 256 characters; blank values are treated as absent.",
+                    "title": "Model"
+                  },
+                  "prompt": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Instructions for how to generate or modify the schema.",
+                    "title": "Prompt"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Existing JSON schema to iterate on or refine.",
+                    "title": "Schema"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  }
+                },
+                "title": "V1BuildSchemaRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "markdown_urls": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "URLs to Markdown files to analyze for schema generation. JSON-serialized string in form data.",
+                    "title": "Markdown Urls"
+                  },
+                  "markdowns": {
+                    "description": "Repeat the field for each file upload.",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "description": "Markdown files or inline content strings to analyze for schema generation. Multiple documents can be provided for better schema coverage.",
+                          "type": "string"
+                        },
+                        {
+                          "description": "File upload.",
+                          "format": "binary",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "type": "array"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "maxLength": 256,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Accepted for v1 wire compatibility and echoed back as `metadata.version`. Schema generation is version-free — this value does NOT select a model and does not change the generated schema. Bounded to 256 characters; blank values are treated as absent. JSON-serialized string in form data.",
+                    "title": "Model"
+                  },
+                  "prompt": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Instructions for how to generate or modify the schema. JSON-serialized string in form data.",
+                    "title": "Prompt"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Existing JSON schema to iterate on or refine. JSON-serialized string in form data.",
+                    "title": "Schema"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this v1-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Extract Jobs",
+        "tags": [
+          "Extract"
+        ]
+      }
+    },
+    "/v1/extract/build-schema/jobs/{job_id}": {
+      "get": {
+        "description": "Get the status of an async Extract job, including its result once the job has completed.",
+        "operationId": "v1-build-schema_get_job",
+        "parameters": [
+          {
+            "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "completed_at": {
+                      "description": "Present once the job is terminal.",
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "description": "Present once status is ``failed``.",
+                      "properties": {
+                        "code": {
+                          "description": "Stable error code (``internal_error`` when unmapped).",
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this v1-build-schema job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "progress": {
+                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "result": {
+                      "anyOf": [
+                        {
+                          "description": "Result returned by V2BuildSchemaOperationWorkflow — the\n``/v2/extract/build-schema`` response body (VTRA ``BuildSchemaResponse``).\n\n``extraction_schema`` is the generated JSON Schema serialized as a STRING\n(VTRA parity — the v1 field is a string, not an object).",
+                          "properties": {
+                            "extraction_schema": {
+                              "description": "The generated JSON schema as a string.",
+                              "title": "Extraction Schema",
+                              "type": "string"
+                            },
+                            "metadata": {
+                              "$ref": "#/components/schemas/V2BuildSchemaMetadata",
+                              "description": "The metadata for the schema generation process."
+                            }
+                          },
+                          "required": [
+                            "extraction_schema",
+                            "metadata"
+                          ],
+                          "title": "V2BuildSchemaResponse",
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Present once status is ``completed``."
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job status / result"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found (e.g. no such job)."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Get Extract Jobs",
+        "tags": [
+          "Extract"
+        ]
+      }
+    },
     "/v2/extract": {
       "post": {
         "description": "Extract structured data from a Markdown document according to a JSON schema, with character-span grounding into the source Markdown. Runs synchronously and returns the result inline.",

--- a/src/resources/v2/types.ts
+++ b/src/resources/v2/types.ts
@@ -165,7 +165,8 @@ export interface V2GroundingBox {
  * Where a node lives: its 1-indexed `page`, its `range` slice of the top-level
  * `markdown`, and its bounding `box` in normalized page coordinates. The same
  * shape is used for page nodes, element nodes, and each `atomic_grounding`
- * entry, so any grounding object is self-contained.
+ * entry, so any grounding object is self-contained. `confidence` is populated
+ * only on word-granularity `atomic_grounding` entries.
  */
 export interface V2Grounding {
   page: number;
@@ -173,6 +174,16 @@ export interface V2Grounding {
   range: V2Range;
 
   box: V2GroundingBox;
+
+  /**
+   * How sure the model is of the text in this segment, in `[0, 1]`. Present only
+   * on word-granularity `atomic_grounding` entries (`dpt-3-fast`), where it is
+   * the lowest per-character OCR confidence in the word — so a word is only as
+   * trustworthy as its weakest character. `null` on node-level `grounding` and
+   * on models that ground at line granularity. Required per spec; the value may
+   * be `null`.
+   */
+  confidence: number | null;
 }
 
 export type V2ElementType =
@@ -201,8 +212,11 @@ export interface V2ParseElement {
   grounding?: V2Grounding;
 
   /**
-   * Fine-grained grounding segments (visual lines today). Present only on leaf
-   * elements; omitted entirely when `options.atomic_grounding` is `false`.
+   * Fine-grained grounding segments, at whichever granularity the model reads
+   * at: one entry per visual line for `dpt-3-pro`, one per word — each with its
+   * `confidence` — for `dpt-3-fast`, including the words inside table cells.
+   * Present only on leaf elements; omitted entirely when
+   * `options.atomic_grounding` is `false`.
    */
   atomic_grounding?: Array<V2Grounding> | null;
 

--- a/tests/api-resources/v2/v2.test.ts
+++ b/tests/api-resources/v2/v2.test.ts
@@ -140,6 +140,82 @@ describe('client.v2 routing', () => {
     expect(res.metadata?.openapi_spec).toBe('https://example.com/spec.json');
   });
 
+  test('parse (sync) surfaces per-word atomic_grounding confidence', async () => {
+    const box = { xmin: 0, ymin: 0, xmax: 1, ymax: 1 };
+    // Word-granularity models (`dpt-3-fast`) emit one `atomic_grounding` entry
+    // per word, each carrying the lowest per-character OCR confidence in that
+    // word. Node-level grounding never carries one, so it arrives as `null`.
+    const { client } = stubClient(() =>
+      jsonResponse({
+        markdown: 'hi there',
+        structure: {
+          type: 'document',
+          children: [
+            {
+              type: 'page',
+              page: 1,
+              grounding: { page: 1, range: { start: 0, end: 8 }, box, confidence: null },
+              children: [
+                {
+                  type: 'text',
+                  id: 'text-0',
+                  grounding: { page: 1, range: { start: 0, end: 8 }, box, confidence: null },
+                  atomic_grounding: [
+                    { page: 1, range: { start: 0, end: 2 }, box, confidence: 0.98 },
+                    { page: 1, range: { start: 3, end: 8 }, box, confidence: 0.42 },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        metadata: { model_version: 'dpt-3-fast-20260710', duration_ms: 12 },
+      }),
+    );
+    const res = await client.v2.parse({
+      document: await toFile(Buffer.from('%PDF'), 'a.pdf'),
+      model: 'dpt-3-fast',
+    });
+    const el = res.structure?.children?.[0]?.children?.[0];
+    expect(el?.atomic_grounding?.map((g) => g.confidence)).toEqual([0.98, 0.42]);
+    // Node-level grounding carries no confidence — it arrives (and stays) `null`.
+    expect(el?.grounding?.confidence).toBeNull();
+    expect(res.structure?.children?.[0]?.grounding?.confidence).toBeNull();
+  });
+
+  test('parseJobs.get carries atomic_grounding confidence through the normalizer', async () => {
+    const box = { xmin: 0.1, ymin: 0.1, xmax: 0.2, ymax: 0.2 };
+    const { client } = stubClient(() =>
+      jsonResponse({
+        job_id: 'pj-conf',
+        status: 'completed',
+        result: {
+          markdown: 'hi',
+          structure: {
+            type: 'document',
+            children: [
+              {
+                type: 'page',
+                page: 1,
+                children: [
+                  {
+                    type: 'text',
+                    id: 'text-0',
+                    atomic_grounding: [{ page: 1, range: { start: 0, end: 2 }, box, confidence: 0.77 }],
+                  },
+                ],
+              },
+            ],
+          },
+          metadata: { duration_ms: 3 },
+        },
+      }),
+    );
+    const job = await client.v2.parseJobs.get('pj-conf');
+    const result = job.result as LandingAIADE.V2ParseResponse;
+    expect(result.structure?.children?.[0]?.children?.[0]?.atomic_grounding?.[0]?.confidence).toBe(0.77);
+  });
+
   test('extract (sync) surfaces model_version, output_ref, and billing counts', async () => {
     const { client } = stubClient(() =>
       jsonResponse({

--- a/tests/contract/v2-production.test.ts
+++ b/tests/contract/v2-production.test.ts
@@ -94,8 +94,8 @@ describe('V2 e2e (production)', () => {
     async () => {
       const client = newClient();
       // Complete a real parse job first so the list assertion below is non-vacuous: an empty page
-      // would let a broken list/normalizer pass this release gate. This also gives the suite its
-      // only real parse (the staging smoke never parses a document).
+      // would let a broken list/normalizer pass this release gate. This is also the suite's only
+      // real parse (the staging smoke parses only for the atomic_grounding confidence check).
       const created = await client.v2.parseJobs.create({
         document: await toFile(pdfBytes, 'sample.pdf', { type: 'application/pdf' }),
       });

--- a/tests/contract/v2-smoke.test.ts
+++ b/tests/contract/v2-smoke.test.ts
@@ -1,4 +1,6 @@
-import LandingAIADE from 'landingai-ade';
+import LandingAIADE, { toFile } from 'landingai-ade';
+import fs from 'fs';
+import path from 'path';
 
 // V2 (`client.v2`) contract smoke test. Like the V1 one, it hits the LIVE staging API — gated on a
 // real key, excluded from the default `./scripts/test` run, and required only on `spec-sync/*`
@@ -10,6 +12,20 @@ const apiKey = process.env['LANDINGAI_ADE_STAGING_APIKEY'];
 const runIf = apiKey ? test : test.skip;
 
 const SAMPLE_MARKDOWN = '# Acme Inc. — Q1 Report\n\nTotal revenue for the quarter was **$1,250,000**.\n';
+const SAMPLE_PDF = path.join(__dirname, 'sample.pdf');
+
+/** Every `atomic_grounding` entry in a parse structure tree, depth-first. */
+function atomicGrounding(structure: LandingAIADE.V2ParseStructure | null | undefined) {
+  const out: LandingAIADE.V2Grounding[] = [];
+  const walk = (el: LandingAIADE.V2ParseElement) => {
+    out.push(...(el.atomic_grounding ?? []));
+    for (const child of el.children ?? []) walk(child);
+  };
+  for (const page of structure?.children ?? []) {
+    for (const el of page.children ?? []) walk(el);
+  }
+  return out;
+}
 
 describe('V2 contract (staging)', () => {
   runIf(
@@ -85,6 +101,41 @@ describe('V2 contract (staging)', () => {
         expect(done.metadata).toBeNull();
         const result = done.result as LandingAIADE.V2ExtractResult;
         expect(typeof result.metadata.duration_ms).toBe('number');
+      }
+    },
+    180_000,
+  );
+
+  runIf(
+    'parse (sync) reports atomic_grounding confidence on a word-granularity model',
+    async () => {
+      const client = new LandingAIADE({ apikey: apiKey!, environment: 'staging' });
+      // Wired by the V2 spec-sync: `atomic_grounding` entries now carry a
+      // `confidence`. `dpt-3-fast` grounds at WORD granularity, and every word
+      // segment reports the lowest per-character OCR confidence in that word;
+      // node-level `grounding` never carries one.
+      const res = await client.v2.parse({
+        document: await toFile(fs.readFileSync(SAMPLE_PDF), 'sample.pdf', { type: 'application/pdf' }),
+        model: 'dpt-3-fast',
+        options: { atomic_grounding: true },
+      });
+      const atoms = atomicGrounding(res.structure);
+      expect(atoms.length).toBeGreaterThan(0);
+      for (const g of atoms) {
+        expect(g.confidence === null || typeof g.confidence === 'number').toBe(true);
+        if (typeof g.confidence === 'number') {
+          expect(g.confidence).toBeGreaterThanOrEqual(0);
+          expect(g.confidence).toBeLessThanOrEqual(1);
+        }
+      }
+      // Only assert presence once the request actually landed on a word-granularity
+      // snapshot — a line-granularity model legitimately omits the field.
+      if (res.metadata?.model_version?.startsWith('dpt-3-fast')) {
+        expect(atoms.some((g) => typeof g.confidence === 'number')).toBe(true);
+      }
+      const pageGrounding = res.structure?.children?.[0]?.grounding;
+      if (pageGrounding) {
+        expect(pageGrounding.confidence ?? null).toBeNull();
       }
     },
     180_000,


### PR DESCRIPTION
Automated V2 spec-sync PR (`client.v2`).

- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference types.
- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff. The shipped-but-hand-maintained `/v2/workflow*` surface is not auto-wired, so workflow-only drift lands as a **mechanical-only PR** for a maintainer to reconcile by hand.

Gates (surface-lock, V2 contract tests, lint/build/test) must pass. The V2 ergonomic layer (unified Job, dual-host, schema coercion) is not in the spec, so when present the AI commit is a **draft a human finishes**. **Human review required before merge.**

<!-- what-changed:start -->
## What changed
_AI-generated from the PR diff — verify against the actual changes._

This PR adds per-word OCR `confidence` to parse grounding for the `dpt-3-fast` model, exposed via a new `confidence` field on `V2Grounding`.

**Changes:**
- Adds `confidence: number | null` field to `V2Grounding`, populated only on word-granularity `atomic_grounding` entries (`dpt-3-fast`), and `null` on node-level grounding or line-granularity models.
- Documents that `atomic_grounding` segments at model-dependent granularity: one entry per visual line for `dpt-3-pro`, one per word (including table-cell words) for `dpt-3-fast`.
- Adds a new `V2GroundingBox` type export alongside the existing `V2Grounding` export in `api.md`.
- Updates README with a new "Grounding confidence" section and example showing how to flag low-confidence words.
- Spec snapshot also updates `/v1/extract/build-schema` (and its jobs sub-routes), but this is not a client-surface change in this PR.
<!-- what-changed:end -->
<!-- spec-sync-nudged: 20679 -->
