### PR TITLE
spec-sync(v2): parse: support password-protected pdf decryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,32 @@ The `document` parameter accepts an `fs.ReadStream`, a web `File`, a `fetch` `Re
 
 The `model` parameter accepts a dated snapshot (`dpt-3-pro-20260710`), a `-latest` alias, or a bare family name (equivalent to that family's `-latest`). Two families are available: `dpt-3-pro` for highest quality, and `dpt-3-verity` for lower-latency parsing without vision-model captioning. It defaults to the latest DPT-3 Pro snapshot.
 
+### Encrypted PDFs
+
+Pass `password` to parse a password-protected PDF. The document is decrypted once at the start of processing, and the password is not retained with the result:
+
+```ts
+const parsed = await client.v2.parse({
+  document: fs.createReadStream('locked.pdf'),
+  password: process.env['PDF_PASSWORD'],
+  options: { inline_markdown: true }, // `password` merges into `options` on the wire
+});
+```
+
+`password` is a top-level convenience param that the SDK folds into the wire's `options` object, so passing it alongside your own `options` merges the two rather than replacing them. It works the same way on `client.v2.parseJobs.create`.
+
+Passwords apply to PDFs only. Supplying one for an image or an Office document fails with a 422 (`password_unsupported_content_type`), a wrong password fails with a 422 (`encrypted_pdf_wrong_password`), and omitting one for a locked PDF fails with a 422 (`encrypted_pdf_password_required`) — all surfaced as an `UnprocessableEntityError` whose `error.code` carries the code:
+
+```ts
+try {
+  await client.v2.parse({ document: fs.createReadStream('locked.pdf') });
+} catch (err) {
+  if (err instanceof LandingAIADE.UnprocessableEntityError) {
+    console.log((err.error as { code?: string }).code); // e.g. 'encrypted_pdf_password_required'
+  }
+}
+```
+
 ## Extract
 
 Use `client.v2.extract` to pull structured fields out of Markdown (typically from a parse response) using a schema. The `schema` parameter accepts a JSON Schema object or a JSON string. Provide exactly one Markdown source: `markdown` or `markdown_url`.

--- a/api.md
+++ b/api.md
@@ -61,6 +61,8 @@ Every node in a parse `structure` tree carries a <a href="./src/resources/v2/typ
 
 A <a href="./src/resources/v2/types.ts">`V2GroundingBox`</a> coordinate arrives at a fixed precision — at most 5 decimal places, clamped and rounded by the gateway before serializing, so it is the stored value rather than a truncation of something finer. `confidence` carries no such promise: the spec pins its `[0, 1]` range only, so compare it against a threshold rather than expecting a fixed number of decimal places.
 
+`client.v2.parse` and `client.v2.parseJobs.create` accept a `password` for an encrypted PDF; it is a top-level convenience param that the SDK folds into the wire's `options` object, so passing both `options` and `password` merges them. The document is decrypted once at the start of processing and the password is not retained with the result. It applies to PDFs only — supplying one for an image or an Office document returns a 422 (`password_unsupported_content_type`) — and a wrong password returns a 422 (`encrypted_pdf_wrong_password`), as does omitting it for a locked PDF (`encrypted_pdf_password_required`).
+
 `client.v2.parseJobs` and `client.v2.extractJobs` both return a single, unified <a href="./src/resources/v2/types.ts">`Job`</a> shape even though the underlying parse/extract job envelopes differ upstream — `Job.raw` retains the full original envelope as an escape hatch. `Job.metadata` carries the envelope's top-level metadata receipt (a <a href="./src/resources/v2/types.ts">`V2ParseMetadata`</a> for parse jobs), returned alongside `raw.output_url` when a job created with `output_save_url` completes; it is `null` for inline jobs, whose metadata lives on `Job.result`.
 
 Types:

--- a/specs/_generated/v2-aide.d.ts
+++ b/specs/_generated/v2-aide.d.ts
@@ -4,6 +4,134 @@
  */
 
 export interface paths {
+    "/v1/ade/classify": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * ADE Classify
+         * @description Classify each page of a document into classes you define. Accepts a PDF, an image, or an Office document, plus the list of candidate classes; returns one predicted class per page. Runs synchronously and returns the result inline.
+         */
+        post: operations["v1-ade-classify_run_sync"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/ade/classify/jobs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * ADE List Classify Jobs
+         * @description List your Classify jobs, newest first.
+         */
+        get: operations["v1-ade-classify_list_jobs"];
+        put?: never;
+        /**
+         * ADE Classify Jobs
+         * @description Classify each page of a document into classes you define. Accepts a PDF, an image, or an Office document, plus the list of candidate classes; returns one predicted class per page. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.
+         */
+        post: operations["v1-ade-classify_create_job"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/ade/classify/jobs/{job_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * ADE Get Classify Jobs
+         * @description Get the status of an async Classify job, including its result once the job has completed.
+         */
+        get: operations["v1-ade-classify_get_job"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/ade/extract": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * ADE Extract
+         * @description Extract structured data from a Markdown document using a JSON Schema. v1-compatible wire, running the same extraction engine as `/v2/extract`. Runs synchronously and returns the result inline.
+         */
+        post: operations["v1-ade-extract_run_sync"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/ade/extract/jobs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * ADE List Extract Jobs
+         * @description List your Extract jobs, newest first.
+         */
+        get: operations["v1-ade-extract_list_jobs"];
+        put?: never;
+        /**
+         * ADE Extract Jobs
+         * @description Extract structured data from a Markdown document using a JSON Schema. v1-compatible wire, running the same extraction engine as `/v2/extract`. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.
+         */
+        post: operations["v1-ade-extract_create_job"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/ade/extract/jobs/{job_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * ADE Get Extract Jobs
+         * @description Get the status of an async Extract job, including its result once the job has completed.
+         */
+        get: operations["v1-ade-extract_get_job"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/ade/parse": {
         parameters: {
             query?: never;
@@ -78,7 +206,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/extract": {
+    "/v1/classify": {
         parameters: {
             query?: never;
             header?: never;
@@ -88,10 +216,54 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * ADE Extract
-         * @description Extract structured data from a Markdown document using a JSON Schema. v1-compatible wire, running the same extraction engine as `/v2/extract`. Runs synchronously and returns the result inline.
+         * ADE Classify
+         * @description Classify each page of a document into classes you define. Accepts a PDF, an image, or an Office document, plus the list of candidate classes; returns one predicted class per page. Runs synchronously and returns the result inline.
          */
-        post: operations["v1-extract_run_sync"];
+        post: operations["classify_run_sync"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/classify/jobs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * ADE List Classify Jobs
+         * @description List your Classify jobs, newest first.
+         */
+        get: operations["classify_list_jobs"];
+        put?: never;
+        /**
+         * ADE Classify Jobs
+         * @description Classify each page of a document into classes you define. Accepts a PDF, an image, or an Office document, plus the list of candidate classes; returns one predicted class per page. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.
+         */
+        post: operations["classify_create_job"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/classify/jobs/{job_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * ADE Get Classify Jobs
+         * @description Get the status of an async Classify job, including its result once the job has completed.
+         */
+        get: operations["classify_get_job"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -162,51 +334,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/extract/jobs": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * ADE List Extract Jobs
-         * @description List your Extract jobs, newest first.
-         */
-        get: operations["v1-extract_list_jobs"];
-        put?: never;
-        /**
-         * ADE Extract Jobs
-         * @description Extract structured data from a Markdown document using a JSON Schema. v1-compatible wire, running the same extraction engine as `/v2/extract`. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.
-         */
-        post: operations["v1-extract_create_job"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/extract/jobs/{job_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * ADE Get Extract Jobs
-         * @description Get the status of an async Extract job, including its result once the job has completed.
-         */
-        get: operations["v1-extract_get_job"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/parse": {
+    "/v1/split": {
         parameters: {
             query?: never;
             header?: never;
@@ -216,64 +344,10 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * ADE Parse v1
-         * @description Run synchronously and return the result inline.
-         *
-         *     Accepts ``application/json`` (the request fields as the body),
-         *     ``multipart/form-data`` (file fields are staged automatically),
-         *     or ``application/x-www-form-urlencoded`` (text fields only).
-         *
-         *     Returns **504** if the work does not finish within the wait
-         *     window — long-running work belongs on the async ``POST
-         *     {path}/jobs`` route, which returns 202 immediately and is polled
-         *     via ``GET {path}/jobs/{job_id}``. On a 504 the workflow is
-         *     CANCELLED (a sync caller can never collect the result); a retry
-         *     starts the work over as a fresh job.
+         * ADE Split
+         * @description Split a Markdown document into segments and return the split response inline.
          */
-        post: operations["parse2_run_sync"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/parse/jobs": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** ADE List Parse v1 Jobs */
-        get: operations["parse2_list_jobs"];
-        put?: never;
-        /** ADE Parse v1 Jobs */
-        post: operations["parse2_create_job"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/parse/jobs/{job_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * ADE Get Parse v1 Jobs
-         * @description Poll a job.
-         *
-         *     Returns ``{job_id, status, created_at}`` plus ``completed_at`` and
-         *     ``result`` (on ``completed``) or ``error: {code, message}`` (on
-         *     ``failed``). Statuses: ``pending`` → ``processing`` →
-         *     ``completed`` | ``failed``.
-         */
-        get: operations["parse2_get_job"];
-        put?: never;
-        post?: never;
+        post: operations["v1-split_run_sync"];
         delete?: never;
         options?: never;
         head?: never;
@@ -571,6 +645,28 @@ export interface components {
              * @description Human-readable description of the warning with more details.
              */
             msg: string;
+        };
+        /**
+         * ClassifyClass
+         * @description One classification option: a class name plus an optional description.
+         *
+         *     Wire key ``class`` (VTRA's ``ClassifyClass``); the field is ``class_name``
+         *     because ``class`` is a Python keyword, with the alias carrying the wire
+         *     name. ``populate_by_name`` lets the Temporal round-trip (which serializes by
+         *     FIELD name) rebuild the object on the worker side.
+         */
+        ClassifyClass: {
+            /**
+             * Class
+             * @description Class name assigned to a page when it matches.
+             */
+            class: string;
+            /**
+             * Description
+             * @description What this class represents. Improves classification.
+             * @default null
+             */
+            description: string | null;
         };
         /**
          * CreditUsage
@@ -912,6 +1008,87 @@ export interface components {
              */
             start: number;
         };
+        /**
+         * Split
+         * @description One split segment: consecutive pages of one classification (an
+         *     identifier change starts a new segment).
+         */
+        Split: {
+            /**
+             * Classification
+             * @description The split classification name this segment was assigned.
+             */
+            classification: string;
+            /**
+             * Identifier
+             * @description The identifier value extracted for this segment, when the matching split classification requested one. Null otherwise.
+             */
+            identifier: string | null;
+            /**
+             * Markdowns
+             * @description The Markdown content of each page in this segment, in order.
+             */
+            markdowns: string[];
+            /**
+             * Pages
+             * @description 0-indexed page numbers belonging to this segment, in order.
+             */
+            pages: number[];
+        };
+        /**
+         * SplitMetadata
+         * @description Information about a split request.
+         */
+        SplitMetadata: {
+            /**
+             * Credit Usage
+             * @description Credits consumed by this request: the input Markdown length in characters divided by 5000. Billed usage rounds this up to the next 0.1 credit.
+             */
+            credit_usage: number;
+            /**
+             * Duration Ms
+             * @description Total processing time in milliseconds.
+             */
+            duration_ms: number;
+            /**
+             * Filename
+             * @description Display name of the split document: the URL path's file name for `markdown_url` inputs, or a generated name for inline and uploaded Markdown.
+             */
+            filename: string;
+            /**
+             * Job Id
+             * @description The split job identifier — server-minted and unique per request. Correlates with the request's entry in your billing dashboard.
+             */
+            job_id: string;
+            /**
+             * Org Id
+             * @description Organization ID.
+             */
+            org_id: string | null;
+            /**
+             * Page Count
+             * @description Total number of pages in the input Markdown.
+             */
+            page_count: number;
+            /**
+             * Version
+             * @description The exact split model snapshot that processed the document, e.g. `split-20251105`.
+             */
+            version: string;
+        };
+        /**
+         * SplitResponse
+         * @description The split result: the merged `splits` segments and request `metadata`.
+         */
+        SplitResponse: {
+            /** @description Information about the request: file name, page count, duration, credits, and the resolved model version. */
+            metadata: components["schemas"]["SplitMetadata"];
+            /**
+             * Splits
+             * @description The split segments, in page order. Consecutive pages with the same classification merge into one segment; an identifier change starts a new segment.
+             */
+            splits: components["schemas"]["Split"][];
+        };
         /** TableOptions */
         TableOptions: {
             /**
@@ -983,6 +1160,54 @@ export interface components {
              * @description Structured warnings from the schema-generation process. Each is a ``{code, msg}`` object (e.g. code ``nonconformant_schema``).
              */
             warnings?: components["schemas"]["BuildSchemaWarning"][];
+        };
+        /**
+         * V1ClassifyMetadata
+         * @description Response metadata for a classify call — VTRA's ``ClassifyMetadata``.
+         */
+        V1ClassifyMetadata: {
+            /**
+             * Credit Usage
+             * @description Credits billed for this request.
+             * @default 0
+             */
+            credit_usage: number;
+            /**
+             * Duration Ms
+             * @description End-to-end request duration in milliseconds.
+             */
+            duration_ms: number;
+            /**
+             * Filename
+             * @description Name of the classified file.
+             * @default
+             */
+            filename: string;
+            /**
+             * Job Id
+             * @description Gateway job id (workflow id). Matches the billing row id in vision-agent.
+             * @default
+             */
+            job_id: string;
+            /** @description URL of the OpenAPI spec covering this API, for inspection and client generation. */
+            openapi_spec: string;
+            /**
+             * Org Id
+             * @description Organization ID.
+             * @default null
+             */
+            org_id: string | null;
+            /**
+             * Page Count
+             * @description Number of pages classified.
+             */
+            page_count: number;
+            /**
+             * Version
+             * @description Resolved classify pipeline version that produced this response.
+             * @default null
+             */
+            version: string | null;
         };
         /**
          * V1ExtractMetadata
@@ -1265,6 +1490,652 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    "v1-ade-classify_run_sync": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Classes
+                     * @description The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.
+                     */
+                    classes: components["schemas"]["ClassifyClass"][];
+                    /**
+                     * Content Type
+                     * @default
+                     */
+                    content_type?: string;
+                    /** Document Ref */
+                    document_ref: string;
+                    /**
+                     * Filename
+                     * @default
+                     */
+                    filename?: string;
+                    /**
+                     * Model
+                     * @description Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.
+                     * @default null
+                     */
+                    model?: string | null;
+                };
+                "multipart/form-data": {
+                    /**
+                     * Classes
+                     * @description The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.
+                     */
+                    classes: components["schemas"]["ClassifyClass"][];
+                    /**
+                     * Content Type
+                     * @default
+                     */
+                    content_type?: string;
+                    /**
+                     * Format: binary
+                     * @description The file to process. Provide either `document` or `document_url`, not both.
+                     */
+                    document?: string;
+                    /** @description A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both. */
+                    document_url?: string;
+                    /**
+                     * Filename
+                     * @default
+                     */
+                    filename?: string;
+                    /**
+                     * Model
+                     * @description Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.
+                     * @default null
+                     */
+                    model?: string | null;
+                };
+            };
+        };
+        responses: {
+            /** @description v1-ade-classify result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * Classification
+                         * @description One classification result per page, in page order.
+                         */
+                        classification: {
+                            /** @description Predicted class label, or 'unknown'. */
+                            class: string;
+                            /** @description Page number, zero-indexed (the first page is 0). */
+                            page: number;
+                            /** @description Why the page was classified this way. */
+                            reason: string;
+                            /** @description A class the model proposes when the prediction is 'unknown'. */
+                            suggested_class?: string | null;
+                        }[];
+                        /** @description Metadata for the classification request. */
+                        metadata: components["schemas"]["V1ClassifyMetadata"];
+                    };
+                };
+            };
+            /** @description Request validation failed. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    "v1-ade-classify_list_jobs": {
+        parameters: {
+            query?: {
+                /** @description Page number (0-indexed). */
+                page?: number;
+                /** @description Number of items per page. */
+                page_size?: number;
+                /** @description Filter by job status. */
+                status?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The caller's jobs, newest first */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        has_more?: boolean;
+                        jobs?: {
+                            completed_at?: string | null;
+                            created_at?: string | null;
+                            failure_reason?: string | null;
+                            /** @description The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
+                            job_id?: string;
+                            model_version?: string | null;
+                            /** @enum {string} */
+                            status?: "pending" | "processing" | "completed" | "failed";
+                        }[];
+                        page?: number;
+                        page_size?: number;
+                    };
+                };
+            };
+            /** @description Request validation failed. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    "v1-ade-classify_create_job": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Classes
+                     * @description The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.
+                     */
+                    classes: components["schemas"]["ClassifyClass"][];
+                    /**
+                     * Content Type
+                     * @default
+                     */
+                    content_type?: string;
+                    /** Document Ref */
+                    document_ref: string;
+                    /**
+                     * Filename
+                     * @default
+                     */
+                    filename?: string;
+                    /**
+                     * Model
+                     * @description Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.
+                     * @default null
+                     */
+                    model?: string | null;
+                    /** @description Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``. */
+                    service_tier?: ("standard" | "priority") | null;
+                };
+                "multipart/form-data": {
+                    /**
+                     * Classes
+                     * @description The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.
+                     */
+                    classes: components["schemas"]["ClassifyClass"][];
+                    /**
+                     * Content Type
+                     * @default
+                     */
+                    content_type?: string;
+                    /**
+                     * Format: binary
+                     * @description The file to process. Provide either `document` or `document_url`, not both.
+                     */
+                    document?: string;
+                    /** @description A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both. */
+                    document_url?: string;
+                    /**
+                     * Filename
+                     * @default
+                     */
+                    filename?: string;
+                    /**
+                     * Model
+                     * @description Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.
+                     * @default null
+                     */
+                    model?: string | null;
+                    /** @description Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``. */
+                    service_tier?: ("standard" | "priority") | null;
+                };
+            };
+        };
+        responses: {
+            /** @description Job created */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        created_at?: string | null;
+                        /** @description The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
+                        job_id?: string;
+                        /** @enum {string} */
+                        status?: "pending" | "processing" | "completed" | "failed";
+                    };
+                };
+            };
+            /** @description Request validation failed. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    "v1-ade-classify_get_job": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The identifier of the job to retrieve, as returned by the create-job request. */
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Job status / result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Present once the job is terminal. */
+                        completed_at?: string;
+                        created_at?: string | null;
+                        /** @description Present once status is ``failed``. */
+                        error?: {
+                            /** @description Stable error code (``internal_error`` when unmapped). */
+                            code?: string;
+                            message?: string;
+                        };
+                        /** @description The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
+                        job_id?: string;
+                        /** @description Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``. */
+                        progress?: number;
+                        /** @description Present once status is ``completed``. */
+                        result?: {
+                            /**
+                             * Classification
+                             * @description One classification result per page, in page order.
+                             */
+                            classification: {
+                                /** @description Predicted class label, or 'unknown'. */
+                                class: string;
+                                /** @description Page number, zero-indexed (the first page is 0). */
+                                page: number;
+                                /** @description Why the page was classified this way. */
+                                reason: string;
+                                /** @description A class the model proposes when the prediction is 'unknown'. */
+                                suggested_class?: string | null;
+                            }[];
+                            /** @description Metadata for the classification request. */
+                            metadata: components["schemas"]["V1ClassifyMetadata"];
+                        } | null;
+                        /** @enum {string} */
+                        status?: "pending" | "processing" | "completed" | "failed";
+                    };
+                };
+            };
+            /** @description Not found (e.g. no such job). */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Request validation failed. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    "v1-ade-extract_run_sync": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Markdown
+                     * @default null
+                     */
+                    markdown?: string | null;
+                    /**
+                     * Markdown Url
+                     * @default null
+                     */
+                    markdown_url?: string | null;
+                    /**
+                     * Model
+                     * @default null
+                     */
+                    model?: string | null;
+                    /**
+                     * Schema
+                     * @default null
+                     */
+                    schema?: string | null;
+                    /**
+                     * Strict
+                     * @default false
+                     */
+                    strict?: boolean;
+                };
+                "multipart/form-data": {
+                    /**
+                     * Format: binary
+                     * @description File upload.
+                     */
+                    markdown?: string;
+                    /**
+                     * Markdown Url
+                     * @description JSON-serialized string in form data.
+                     * @default null
+                     */
+                    markdown_url?: string | null;
+                    /**
+                     * Model
+                     * @description JSON-serialized string in form data.
+                     * @default null
+                     */
+                    model?: string | null;
+                    /**
+                     * Schema
+                     * @description JSON-serialized string in form data.
+                     * @default null
+                     */
+                    schema?: string | null;
+                    /**
+                     * Strict
+                     * @description JSON-serialized string in form data.
+                     * @default false
+                     */
+                    strict?: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description v1-ade-extract result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** Extraction */
+                        extraction?: {
+                            [key: string]: unknown;
+                        };
+                        /** Extraction Metadata */
+                        extraction_metadata?: {
+                            [key: string]: unknown;
+                        };
+                        metadata?: components["schemas"]["V1ExtractMetadata"];
+                    };
+                };
+            };
+            /** @description Request validation failed. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    "v1-ade-extract_list_jobs": {
+        parameters: {
+            query?: {
+                /** @description Page number (0-indexed). */
+                page?: number;
+                /** @description Number of items per page. */
+                page_size?: number;
+                /** @description Filter by job status. */
+                status?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The caller's jobs, newest first */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        has_more?: boolean;
+                        jobs?: {
+                            completed_at?: string | null;
+                            created_at?: string | null;
+                            failure_reason?: string | null;
+                            /** @description The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
+                            job_id?: string;
+                            model_version?: string | null;
+                            /** @enum {string} */
+                            status?: "pending" | "processing" | "completed" | "failed";
+                        }[];
+                        page?: number;
+                        page_size?: number;
+                    };
+                };
+            };
+            /** @description Request validation failed. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    "v1-ade-extract_create_job": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Markdown
+                     * @default null
+                     */
+                    markdown?: string | null;
+                    /**
+                     * Markdown Url
+                     * @default null
+                     */
+                    markdown_url?: string | null;
+                    /**
+                     * Model
+                     * @default null
+                     */
+                    model?: string | null;
+                    /**
+                     * Schema
+                     * @default null
+                     */
+                    schema?: string | null;
+                    /** @description Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``. */
+                    service_tier?: ("standard" | "priority") | null;
+                    /**
+                     * Strict
+                     * @default false
+                     */
+                    strict?: boolean;
+                };
+                "multipart/form-data": {
+                    /**
+                     * Format: binary
+                     * @description File upload.
+                     */
+                    markdown?: string;
+                    /**
+                     * Markdown Url
+                     * @description JSON-serialized string in form data.
+                     * @default null
+                     */
+                    markdown_url?: string | null;
+                    /**
+                     * Model
+                     * @description JSON-serialized string in form data.
+                     * @default null
+                     */
+                    model?: string | null;
+                    /**
+                     * Schema
+                     * @description JSON-serialized string in form data.
+                     * @default null
+                     */
+                    schema?: string | null;
+                    /** @description Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``. */
+                    service_tier?: ("standard" | "priority") | null;
+                    /**
+                     * Strict
+                     * @description JSON-serialized string in form data.
+                     * @default false
+                     */
+                    strict?: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description Job created */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        created_at?: string | null;
+                        /** @description The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
+                        job_id?: string;
+                        /** @enum {string} */
+                        status?: "pending" | "processing" | "completed" | "failed";
+                    };
+                };
+            };
+            /** @description Request validation failed. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    "v1-ade-extract_get_job": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The identifier of the job to retrieve, as returned by the create-job request. */
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Job status / result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Present once the job is terminal. */
+                        completed_at?: string;
+                        created_at?: string | null;
+                        /** @description Present once status is ``failed``. */
+                        error?: {
+                            /** @description Stable error code (``internal_error`` when unmapped). */
+                            code?: string;
+                            message?: string;
+                        };
+                        /** @description The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
+                        job_id?: string;
+                        /** @description Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``. */
+                        progress?: number;
+                        /** @description Present once status is ``completed``. */
+                        result?: {
+                            /** Extraction */
+                            extraction?: {
+                                [key: string]: unknown;
+                            };
+                            /** Extraction Metadata */
+                            extraction_metadata?: {
+                                [key: string]: unknown;
+                            };
+                            metadata?: components["schemas"]["V1ExtractMetadata"];
+                        } | null;
+                        /** @enum {string} */
+                        status?: "pending" | "processing" | "completed" | "failed";
+                    };
+                };
+            };
+            /** @description Not found (e.g. no such job). */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Request validation failed. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
     "v1-ade-parse_run_sync": {
         parameters: {
             query?: never;
@@ -1344,9 +2215,11 @@ export interface operations {
                     } | null;
                     /**
                      * Format: binary
-                     * @description File upload.
+                     * @description The file to process. Provide either `document` or `document_url`, not both.
                      */
-                    document_ref: string;
+                    document?: string;
+                    /** @description A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both. */
+                    document_url?: string;
                     /** Filename */
                     filename: string;
                     /**
@@ -1419,6 +2292,11 @@ export interface operations {
                          * @default 0
                          */
                         billable_pages: number;
+                        /**
+                         * Billing Suppressed
+                         * @default false
+                         */
+                        billing_suppressed: boolean;
                         /**
                          * Completion Tokens
                          * @default 0
@@ -1630,9 +2508,11 @@ export interface operations {
                     } | null;
                     /**
                      * Format: binary
-                     * @description File upload.
+                     * @description The file to process. Provide either `document` or `document_url`, not both.
                      */
-                    document_ref: string;
+                    document?: string;
+                    /** @description A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both. */
+                    document_url?: string;
                     /** Filename */
                     filename: string;
                     /**
@@ -1771,6 +2651,11 @@ export interface operations {
                              */
                             billable_pages: number;
                             /**
+                             * Billing Suppressed
+                             * @default false
+                             */
+                            billing_suppressed: boolean;
+                            /**
                              * Completion Tokens
                              * @default 0
                              */
@@ -1857,7 +2742,7 @@ export interface operations {
             };
         };
     };
-    "v1-extract_run_sync": {
+    classify_run_sync: {
         parameters: {
             query?: never;
             header?: never;
@@ -1868,82 +2753,309 @@ export interface operations {
             content: {
                 "application/json": {
                     /**
-                     * Markdown
-                     * @default null
+                     * Classes
+                     * @description The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.
                      */
-                    markdown?: string | null;
+                    classes: components["schemas"]["ClassifyClass"][];
                     /**
-                     * Markdown Url
-                     * @default null
+                     * Content Type
+                     * @default
                      */
-                    markdown_url?: string | null;
+                    content_type?: string;
+                    /** Document Ref */
+                    document_ref: string;
+                    /**
+                     * Filename
+                     * @default
+                     */
+                    filename?: string;
                     /**
                      * Model
+                     * @description Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.
                      * @default null
                      */
                     model?: string | null;
-                    /**
-                     * Schema
-                     * @default null
-                     */
-                    schema?: string | null;
-                    /**
-                     * Strict
-                     * @default false
-                     */
-                    strict?: boolean;
                 };
                 "multipart/form-data": {
                     /**
-                     * Format: binary
-                     * @description File upload.
+                     * Classes
+                     * @description The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.
                      */
-                    markdown?: string;
+                    classes: components["schemas"]["ClassifyClass"][];
                     /**
-                     * Markdown Url
-                     * @description JSON-serialized string in form data.
-                     * @default null
+                     * Content Type
+                     * @default
                      */
-                    markdown_url?: string | null;
+                    content_type?: string;
+                    /**
+                     * Format: binary
+                     * @description The file to process. Provide either `document` or `document_url`, not both.
+                     */
+                    document?: string;
+                    /** @description A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both. */
+                    document_url?: string;
+                    /**
+                     * Filename
+                     * @default
+                     */
+                    filename?: string;
                     /**
                      * Model
-                     * @description JSON-serialized string in form data.
+                     * @description Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.
                      * @default null
                      */
                     model?: string | null;
-                    /**
-                     * Schema
-                     * @description JSON-serialized string in form data.
-                     * @default null
-                     */
-                    schema?: string | null;
-                    /**
-                     * Strict
-                     * @description JSON-serialized string in form data.
-                     * @default false
-                     */
-                    strict?: boolean;
                 };
             };
         };
         responses: {
-            /** @description v1-extract result */
+            /** @description classify result */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
                     "application/json": {
-                        /** Extraction */
-                        extraction?: {
-                            [key: string]: unknown;
-                        };
-                        /** Extraction Metadata */
-                        extraction_metadata?: {
-                            [key: string]: unknown;
-                        };
-                        metadata?: components["schemas"]["V1ExtractMetadata"];
+                        /**
+                         * Classification
+                         * @description One classification result per page, in page order.
+                         */
+                        classification: {
+                            /** @description Predicted class label, or 'unknown'. */
+                            class: string;
+                            /** @description Page number, zero-indexed (the first page is 0). */
+                            page: number;
+                            /** @description Why the page was classified this way. */
+                            reason: string;
+                            /** @description A class the model proposes when the prediction is 'unknown'. */
+                            suggested_class?: string | null;
+                        }[];
+                        /** @description Metadata for the classification request. */
+                        metadata: components["schemas"]["V1ClassifyMetadata"];
                     };
+                };
+            };
+            /** @description Request validation failed. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    classify_list_jobs: {
+        parameters: {
+            query?: {
+                /** @description Page number (0-indexed). */
+                page?: number;
+                /** @description Number of items per page. */
+                page_size?: number;
+                /** @description Filter by job status. */
+                status?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The caller's jobs, newest first */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        has_more?: boolean;
+                        jobs?: {
+                            completed_at?: string | null;
+                            created_at?: string | null;
+                            failure_reason?: string | null;
+                            /** @description The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
+                            job_id?: string;
+                            model_version?: string | null;
+                            /** @enum {string} */
+                            status?: "pending" | "processing" | "completed" | "failed";
+                        }[];
+                        page?: number;
+                        page_size?: number;
+                    };
+                };
+            };
+            /** @description Request validation failed. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    classify_create_job: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Classes
+                     * @description The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.
+                     */
+                    classes: components["schemas"]["ClassifyClass"][];
+                    /**
+                     * Content Type
+                     * @default
+                     */
+                    content_type?: string;
+                    /** Document Ref */
+                    document_ref: string;
+                    /**
+                     * Filename
+                     * @default
+                     */
+                    filename?: string;
+                    /**
+                     * Model
+                     * @description Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.
+                     * @default null
+                     */
+                    model?: string | null;
+                    /** @description Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``. */
+                    service_tier?: ("standard" | "priority") | null;
+                };
+                "multipart/form-data": {
+                    /**
+                     * Classes
+                     * @description The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.
+                     */
+                    classes: components["schemas"]["ClassifyClass"][];
+                    /**
+                     * Content Type
+                     * @default
+                     */
+                    content_type?: string;
+                    /**
+                     * Format: binary
+                     * @description The file to process. Provide either `document` or `document_url`, not both.
+                     */
+                    document?: string;
+                    /** @description A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both. */
+                    document_url?: string;
+                    /**
+                     * Filename
+                     * @default
+                     */
+                    filename?: string;
+                    /**
+                     * Model
+                     * @description Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.
+                     * @default null
+                     */
+                    model?: string | null;
+                    /** @description Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``. */
+                    service_tier?: ("standard" | "priority") | null;
+                };
+            };
+        };
+        responses: {
+            /** @description Job created */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        created_at?: string | null;
+                        /** @description The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
+                        job_id?: string;
+                        /** @enum {string} */
+                        status?: "pending" | "processing" | "completed" | "failed";
+                    };
+                };
+            };
+            /** @description Request validation failed. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    classify_get_job: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The identifier of the job to retrieve, as returned by the create-job request. */
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Job status / result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Present once the job is terminal. */
+                        completed_at?: string;
+                        created_at?: string | null;
+                        /** @description Present once status is ``failed``. */
+                        error?: {
+                            /** @description Stable error code (``internal_error`` when unmapped). */
+                            code?: string;
+                            message?: string;
+                        };
+                        /** @description The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
+                        job_id?: string;
+                        /** @description Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``. */
+                        progress?: number;
+                        /** @description Present once status is ``completed``. */
+                        result?: {
+                            /**
+                             * Classification
+                             * @description One classification result per page, in page order.
+                             */
+                            classification: {
+                                /** @description Predicted class label, or 'unknown'. */
+                                class: string;
+                                /** @description Page number, zero-indexed (the first page is 0). */
+                                page: number;
+                                /** @description Why the page was classified this way. */
+                                reason: string;
+                                /** @description A class the model proposes when the prediction is 'unknown'. */
+                                suggested_class?: string | null;
+                            }[];
+                            /** @description Metadata for the classification request. */
+                            metadata: components["schemas"]["V1ClassifyMetadata"];
+                        } | null;
+                        /** @enum {string} */
+                        status?: "pending" | "processing" | "completed" | "failed";
+                    };
+                };
+            };
+            /** @description Not found (e.g. no such job). */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Request validation failed. */
@@ -2276,57 +3388,7 @@ export interface operations {
             };
         };
     };
-    "v1-extract_list_jobs": {
-        parameters: {
-            query?: {
-                /** @description Page number (0-indexed). */
-                page?: number;
-                /** @description Number of items per page. */
-                page_size?: number;
-                /** @description Filter by job status. */
-                status?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description The caller's jobs, newest first */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        has_more?: boolean;
-                        jobs?: {
-                            completed_at?: string | null;
-                            created_at?: string | null;
-                            failure_reason?: string | null;
-                            /** @description The unique identifier for this v1-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
-                            job_id?: string;
-                            model_version?: string | null;
-                            /** @enum {string} */
-                            status?: "pending" | "processing" | "completed" | "failed";
-                        }[];
-                        page?: number;
-                        page_size?: number;
-                    };
-                };
-            };
-            /** @description Request validation failed. */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    "v1-extract_create_job": {
+    "v1-split_run_sync": {
         parameters: {
             query?: never;
             header?: never;
@@ -2335,745 +3397,26 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": {
-                    /**
-                     * Markdown
-                     * @default null
-                     */
-                    markdown?: string | null;
-                    /**
-                     * Markdown Url
-                     * @default null
-                     */
-                    markdown_url?: string | null;
-                    /**
-                     * Model
-                     * @default null
-                     */
-                    model?: string | null;
-                    /**
-                     * Schema
-                     * @default null
-                     */
-                    schema?: string | null;
-                    /** @description Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``. */
-                    service_tier?: ("standard" | "priority") | null;
-                    /**
-                     * Strict
-                     * @default false
-                     */
-                    strict?: boolean;
-                };
                 "multipart/form-data": {
-                    /**
-                     * Format: binary
-                     * @description File upload.
-                     */
+                    /** @description Markdown content to split, as an inline string or an uploaded file. Provide either `markdown` or `markdown_url`, not both. */
                     markdown?: string;
-                    /**
-                     * Markdown Url
-                     * @description JSON-serialized string in form data.
-                     * @default null
-                     */
-                    markdown_url?: string | null;
-                    /**
-                     * Model
-                     * @description JSON-serialized string in form data.
-                     * @default null
-                     */
-                    model?: string | null;
-                    /**
-                     * Schema
-                     * @description JSON-serialized string in form data.
-                     * @default null
-                     */
-                    schema?: string | null;
-                    /** @description Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``. */
-                    service_tier?: ("standard" | "priority") | null;
-                    /**
-                     * Strict
-                     * @description JSON-serialized string in form data.
-                     * @default false
-                     */
-                    strict?: boolean;
+                    /** @description A publicly accessible URL to the Markdown file to split. Provide either `markdown` or `markdown_url`, not both. */
+                    markdown_url?: string;
+                    /** @description The split model version to use. Accepts a dated snapshot (`split-20251105`), `split-latest`, or `split` (both aliases resolve to the latest snapshot). Defaults to the latest snapshot. The resolved version is echoed back as `metadata.version`. */
+                    model?: string;
+                    /** @description The split classification entries, as a JSON-encoded array of objects with `name` (required), `description`, and `identifier` keys. At most 19 entries. Sent as a JSON-serialized string in form data. */
+                    split_class: string;
                 };
             };
         };
         responses: {
-            /** @description Job created */
-            202: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        created_at?: string | null;
-                        /** @description The unique identifier for this v1-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
-                        job_id?: string;
-                        /** @enum {string} */
-                        status?: "pending" | "processing" | "completed" | "failed";
-                    };
-                };
-            };
-            /** @description Request validation failed. */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    "v1-extract_get_job": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The identifier of the job to retrieve, as returned by the create-job request. */
-                job_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Job status / result */
+            /** @description The split response */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        /** @description Present once the job is terminal. */
-                        completed_at?: string;
-                        created_at?: string | null;
-                        /** @description Present once status is ``failed``. */
-                        error?: {
-                            /** @description Stable error code (``internal_error`` when unmapped). */
-                            code?: string;
-                            message?: string;
-                        };
-                        /** @description The unique identifier for this v1-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
-                        job_id?: string;
-                        /** @description Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``. */
-                        progress?: number;
-                        /** @description Present once status is ``completed``. */
-                        result?: {
-                            /** Extraction */
-                            extraction?: {
-                                [key: string]: unknown;
-                            };
-                            /** Extraction Metadata */
-                            extraction_metadata?: {
-                                [key: string]: unknown;
-                            };
-                            metadata?: components["schemas"]["V1ExtractMetadata"];
-                        } | null;
-                        /** @enum {string} */
-                        status?: "pending" | "processing" | "completed" | "failed";
-                    };
-                };
-            };
-            /** @description Not found (e.g. no such job). */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Request validation failed. */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    parse2_run_sync: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** Content Type */
-                    content_type: string;
-                    /**
-                     * Custom Prompts
-                     * @default null
-                     */
-                    custom_prompts?: {
-                        [key: string]: string;
-                    } | null;
-                    /** Document Ref */
-                    document_ref: string;
-                    /** Filename */
-                    filename: string;
-                    /**
-                     * Job Id
-                     * @default null
-                     */
-                    job_id?: string | null;
-                    /**
-                     * Model Versions
-                     * @default null
-                     */
-                    model_versions?: {
-                        [key: string]: string;
-                    } | null;
-                    /**
-                     * Password
-                     * @default null
-                     */
-                    password?: string | null;
-                    /**
-                     * Pricing Multiplier
-                     * @default 1
-                     */
-                    pricing_multiplier?: number;
-                    /**
-                     * Processing Mode
-                     * @default sync
-                     */
-                    processing_mode?: string;
-                    /**
-                     * Split
-                     * @default null
-                     */
-                    split?: string | null;
-                    /**
-                     * Version
-                     * @default null
-                     */
-                    version?: string | null;
-                    /**
-                     * X Request Id
-                     * @default null
-                     */
-                    x_request_id?: string | null;
-                };
-                "multipart/form-data": {
-                    /** Content Type */
-                    content_type: string;
-                    /**
-                     * Custom Prompts
-                     * @description JSON-serialized string in form data.
-                     * @default null
-                     */
-                    custom_prompts?: {
-                        [key: string]: string;
-                    } | null;
-                    /**
-                     * Format: binary
-                     * @description File upload.
-                     */
-                    document_ref: string;
-                    /** Filename */
-                    filename: string;
-                    /**
-                     * Job Id
-                     * @description JSON-serialized string in form data.
-                     * @default null
-                     */
-                    job_id?: string | null;
-                    /**
-                     * Model Versions
-                     * @description JSON-serialized string in form data.
-                     * @default null
-                     */
-                    model_versions?: {
-                        [key: string]: string;
-                    } | null;
-                    /**
-                     * Password
-                     * @description JSON-serialized string in form data.
-                     * @default null
-                     */
-                    password?: string | null;
-                    /**
-                     * Pricing Multiplier
-                     * @description JSON-serialized string in form data.
-                     * @default 1
-                     */
-                    pricing_multiplier?: number;
-                    /**
-                     * Processing Mode
-                     * @default sync
-                     */
-                    processing_mode?: string;
-                    /**
-                     * Split
-                     * @description JSON-serialized string in form data.
-                     * @default null
-                     */
-                    split?: string | null;
-                    /**
-                     * Version
-                     * @description JSON-serialized string in form data.
-                     * @default null
-                     */
-                    version?: string | null;
-                    /**
-                     * X Request Id
-                     * @description JSON-serialized string in form data.
-                     * @default null
-                     */
-                    x_request_id?: string | null;
-                };
-            };
-        };
-        responses: {
-            /** @description parse2 result */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /**
-                         * Base Credit
-                         * @default 0
-                         */
-                        base_credit: number;
-                        /**
-                         * Billable Pages
-                         * @default 0
-                         */
-                        billable_pages: number;
-                        /**
-                         * Completion Tokens
-                         * @default 0
-                         */
-                        completion_tokens: number;
-                        credit_usage?: components["schemas"]["CreditUsage"];
-                        /**
-                         * Duration Ms
-                         * @default 0
-                         */
-                        duration_ms: number;
-                        /** Failed Pages */
-                        failed_pages?: number[];
-                        /**
-                         * Model Family
-                         * @default null
-                         */
-                        model_family: string | null;
-                        /**
-                         * Output Ref
-                         * @default null
-                         */
-                        output_ref: string | null;
-                        /**
-                         * Page Count
-                         * @default 0
-                         */
-                        page_count: number;
-                        /**
-                         * Prompt Tokens
-                         * @default 0
-                         */
-                        prompt_tokens: number;
-                        /** Response */
-                        response: {
-                            [key: string]: unknown;
-                        };
-                        /**
-                         * Status Code
-                         * @default 200
-                         */
-                        status_code: number;
-                        /**
-                         * Token Steps
-                         * @default null
-                         */
-                        token_steps: {
-                            [key: string]: unknown;
-                        }[] | null;
-                        /**
-                         * Total Tokens
-                         * @default 0
-                         */
-                        total_tokens: number;
-                        /**
-                         * Usage
-                         * @default null
-                         */
-                        usage: {
-                            [key: string]: unknown;
-                        } | null;
-                    };
-                };
-            };
-            /** @description Request validation failed. */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    parse2_list_jobs: {
-        parameters: {
-            query?: {
-                /** @description Page number (0-indexed). */
-                page?: number;
-                /** @description Number of items per page. */
-                page_size?: number;
-                /** @description Filter by job status. */
-                status?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description The caller's jobs, newest first */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        has_more?: boolean;
-                        jobs?: {
-                            completed_at?: string | null;
-                            created_at?: string | null;
-                            failure_reason?: string | null;
-                            /** @description The unique identifier for this parse2 job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
-                            job_id?: string;
-                            model_version?: string | null;
-                            /** @enum {string} */
-                            status?: "pending" | "processing" | "completed" | "failed";
-                        }[];
-                        page?: number;
-                        page_size?: number;
-                    };
-                };
-            };
-            /** @description Request validation failed. */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    parse2_create_job: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** Content Type */
-                    content_type: string;
-                    /**
-                     * Custom Prompts
-                     * @default null
-                     */
-                    custom_prompts?: {
-                        [key: string]: string;
-                    } | null;
-                    /** Document Ref */
-                    document_ref: string;
-                    /** Filename */
-                    filename: string;
-                    /**
-                     * Job Id
-                     * @default null
-                     */
-                    job_id?: string | null;
-                    /**
-                     * Model Versions
-                     * @default null
-                     */
-                    model_versions?: {
-                        [key: string]: string;
-                    } | null;
-                    /**
-                     * Output Save Url
-                     * @default null
-                     */
-                    output_save_url?: string | null;
-                    /**
-                     * Password
-                     * @default null
-                     */
-                    password?: string | null;
-                    /**
-                     * Pricing Multiplier
-                     * @default 1
-                     */
-                    pricing_multiplier?: number;
-                    /**
-                     * Processing Mode
-                     * @default sync
-                     */
-                    processing_mode?: string;
-                    /** @description Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``. */
-                    service_tier?: ("standard" | "priority") | null;
-                    /**
-                     * Split
-                     * @default null
-                     */
-                    split?: string | null;
-                    /**
-                     * Version
-                     * @default null
-                     */
-                    version?: string | null;
-                    /**
-                     * X Request Id
-                     * @default null
-                     */
-                    x_request_id?: string | null;
-                };
-                "multipart/form-data": {
-                    /** Content Type */
-                    content_type: string;
-                    /**
-                     * Custom Prompts
-                     * @description JSON-serialized string in form data.
-                     * @default null
-                     */
-                    custom_prompts?: {
-                        [key: string]: string;
-                    } | null;
-                    /**
-                     * Format: binary
-                     * @description File upload.
-                     */
-                    document_ref: string;
-                    /** Filename */
-                    filename: string;
-                    /**
-                     * Job Id
-                     * @description JSON-serialized string in form data.
-                     * @default null
-                     */
-                    job_id?: string | null;
-                    /**
-                     * Model Versions
-                     * @description JSON-serialized string in form data.
-                     * @default null
-                     */
-                    model_versions?: {
-                        [key: string]: string;
-                    } | null;
-                    /**
-                     * Output Save Url
-                     * @description JSON-serialized string in form data.
-                     * @default null
-                     */
-                    output_save_url?: string | null;
-                    /**
-                     * Password
-                     * @description JSON-serialized string in form data.
-                     * @default null
-                     */
-                    password?: string | null;
-                    /**
-                     * Pricing Multiplier
-                     * @description JSON-serialized string in form data.
-                     * @default 1
-                     */
-                    pricing_multiplier?: number;
-                    /**
-                     * Processing Mode
-                     * @default sync
-                     */
-                    processing_mode?: string;
-                    /** @description Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``. */
-                    service_tier?: ("standard" | "priority") | null;
-                    /**
-                     * Split
-                     * @description JSON-serialized string in form data.
-                     * @default null
-                     */
-                    split?: string | null;
-                    /**
-                     * Version
-                     * @description JSON-serialized string in form data.
-                     * @default null
-                     */
-                    version?: string | null;
-                    /**
-                     * X Request Id
-                     * @description JSON-serialized string in form data.
-                     * @default null
-                     */
-                    x_request_id?: string | null;
-                };
-            };
-        };
-        responses: {
-            /** @description Job created */
-            202: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        created_at?: string | null;
-                        /** @description The unique identifier for this parse2 job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
-                        job_id?: string;
-                        /** @enum {string} */
-                        status?: "pending" | "processing" | "completed" | "failed";
-                    };
-                };
-            };
-            /** @description Request validation failed. */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    parse2_get_job: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The identifier of the job to retrieve, as returned by the create-job request. */
-                job_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Job status / result */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @description Present once the job is terminal. */
-                        completed_at?: string;
-                        created_at?: string | null;
-                        /** @description Present once status is ``failed``. */
-                        error?: {
-                            /** @description Stable error code (``internal_error`` when unmapped). */
-                            code?: string;
-                            message?: string;
-                        };
-                        /** @description The unique identifier for this parse2 job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
-                        job_id?: string;
-                        /** @description The result's metadata block (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Same shape as the inline ``result``'s ``metadata``; inline jobs carry it there instead. */
-                        metadata?: Record<string, never> | null;
-                        /** @description The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``. */
-                        output_url?: string | null;
-                        /** @description Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``. */
-                        progress?: number;
-                        /** @description Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead. */
-                        result?: {
-                            /**
-                             * Base Credit
-                             * @default 0
-                             */
-                            base_credit: number;
-                            /**
-                             * Billable Pages
-                             * @default 0
-                             */
-                            billable_pages: number;
-                            /**
-                             * Completion Tokens
-                             * @default 0
-                             */
-                            completion_tokens: number;
-                            credit_usage?: components["schemas"]["CreditUsage"];
-                            /**
-                             * Duration Ms
-                             * @default 0
-                             */
-                            duration_ms: number;
-                            /** Failed Pages */
-                            failed_pages?: number[];
-                            /**
-                             * Model Family
-                             * @default null
-                             */
-                            model_family: string | null;
-                            /**
-                             * Output Ref
-                             * @default null
-                             */
-                            output_ref: string | null;
-                            /**
-                             * Page Count
-                             * @default 0
-                             */
-                            page_count: number;
-                            /**
-                             * Prompt Tokens
-                             * @default 0
-                             */
-                            prompt_tokens: number;
-                            /** Response */
-                            response: {
-                                [key: string]: unknown;
-                            };
-                            /**
-                             * Status Code
-                             * @default 200
-                             */
-                            status_code: number;
-                            /**
-                             * Token Steps
-                             * @default null
-                             */
-                            token_steps: {
-                                [key: string]: unknown;
-                            }[] | null;
-                            /**
-                             * Total Tokens
-                             * @default 0
-                             */
-                            total_tokens: number;
-                            /**
-                             * Usage
-                             * @default null
-                             */
-                            usage: {
-                                [key: string]: unknown;
-                            } | null;
-                        } | null;
-                        /** @enum {string} */
-                        status?: "pending" | "processing" | "completed" | "failed";
-                    };
-                };
-            };
-            /** @description Not found (e.g. no such job). */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
+                    "application/json": components["schemas"]["SplitResponse"];
                 };
             };
             /** @description Request validation failed. */
@@ -3688,7 +4031,7 @@ export interface operations {
                         pages?: number[] | null;
                         /**
                          * Password
-                         * @description Password for encrypted PDFs. Not currently supported — providing a value returns a 422 error; decrypt the file before uploading.
+                         * @description Password for an encrypted PDF. The document is decrypted once at the start of processing; the password is not retained with the result. PDFs only — supplying one for an image or Office document returns a 422 (`password_unsupported_content_type`). A wrong password returns a 422 (`encrypted_pdf_wrong_password`); omitting it for a locked PDF returns a 422 (`encrypted_pdf_password_required`).
                          * @default null
                          */
                         password?: string | null;
@@ -3831,7 +4174,7 @@ export interface operations {
                         pages?: number[] | null;
                         /**
                          * Password
-                         * @description Password for encrypted PDFs. Not currently supported — providing a value returns a 422 error; decrypt the file before uploading.
+                         * @description Password for an encrypted PDF. The document is decrypted once at the start of processing; the password is not retained with the result. PDFs only — supplying one for an image or Office document returns a 422 (`password_unsupported_content_type`). A wrong password returns a 422 (`encrypted_pdf_wrong_password`); omitting it for a locked PDF returns a 422 (`encrypted_pdf_password_required`).
                          * @default null
                          */
                         password?: string | null;

--- a/specs/v2-aide.json
+++ b/specs/v2-aide.json
@@ -98,6 +98,34 @@
         "title": "BuildSchemaWarning",
         "type": "object"
       },
+      "ClassifyClass": {
+        "description": "One classification option: a class name plus an optional description.\n\nWire key ``class`` (VTRA's ``ClassifyClass``); the field is ``class_name``\nbecause ``class`` is a Python keyword, with the alias carrying the wire\nname. ``populate_by_name`` lets the Temporal round-trip (which serializes by\nFIELD name) rebuild the object on the worker side.",
+        "properties": {
+          "class": {
+            "description": "Class name assigned to a page when it matches.",
+            "title": "Class",
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "What this class represents. Improves classification.",
+            "title": "Description"
+          }
+        },
+        "required": [
+          "class"
+        ],
+        "title": "ClassifyClass",
+        "type": "object"
+      },
       "CreditUsage": {
         "description": "The standard credit-usage shape a billable WORK result carries.\n\nA billed passthrough operation's work result declares\n``credit_usage: CreditUsage`` and the gateway's default\n``build_success_record`` bills it verbatim — no per-op billing code\n(operations/base.py requires it: a result carrying anything else raises).\n\nStdlib result modules embedding CreditUsage should follow the pdf.py posture\n(no ``from __future__ import annotations``) or use pydantic dataclasses (the\nextract_v2 posture).",
         "properties": {
@@ -675,6 +703,133 @@
         "title": "Range",
         "type": "object"
       },
+      "Split": {
+        "description": "One split segment: consecutive pages of one classification (an\nidentifier change starts a new segment).",
+        "properties": {
+          "classification": {
+            "description": "The split classification name this segment was assigned.",
+            "title": "Classification",
+            "type": "string"
+          },
+          "identifier": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The identifier value extracted for this segment, when the matching split classification requested one. Null otherwise.",
+            "title": "Identifier"
+          },
+          "markdowns": {
+            "description": "The Markdown content of each page in this segment, in order.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Markdowns",
+            "type": "array"
+          },
+          "pages": {
+            "description": "0-indexed page numbers belonging to this segment, in order.",
+            "items": {
+              "type": "integer"
+            },
+            "title": "Pages",
+            "type": "array"
+          }
+        },
+        "required": [
+          "classification",
+          "identifier",
+          "pages",
+          "markdowns"
+        ],
+        "title": "Split",
+        "type": "object"
+      },
+      "SplitMetadata": {
+        "description": "Information about a split request.",
+        "properties": {
+          "credit_usage": {
+            "description": "Credits consumed by this request: the input Markdown length in characters divided by 5000. Billed usage rounds this up to the next 0.1 credit.",
+            "title": "Credit Usage",
+            "type": "number"
+          },
+          "duration_ms": {
+            "description": "Total processing time in milliseconds.",
+            "title": "Duration Ms",
+            "type": "integer"
+          },
+          "filename": {
+            "description": "Display name of the split document: the URL path's file name for `markdown_url` inputs, or a generated name for inline and uploaded Markdown.",
+            "title": "Filename",
+            "type": "string"
+          },
+          "job_id": {
+            "description": "The split job identifier — server-minted and unique per request. Correlates with the request's entry in your billing dashboard.",
+            "title": "Job Id",
+            "type": "string"
+          },
+          "org_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Organization ID.",
+            "title": "Org Id"
+          },
+          "page_count": {
+            "description": "Total number of pages in the input Markdown.",
+            "title": "Page Count",
+            "type": "integer"
+          },
+          "version": {
+            "description": "The exact split model snapshot that processed the document, e.g. `split-20251105`.",
+            "title": "Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "filename",
+          "org_id",
+          "page_count",
+          "duration_ms",
+          "credit_usage",
+          "job_id",
+          "version"
+        ],
+        "title": "SplitMetadata",
+        "type": "object"
+      },
+      "SplitResponse": {
+        "description": "The split result: the merged `splits` segments and request `metadata`.",
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/SplitMetadata",
+            "description": "Information about the request: file name, page count, duration, credits, and the resolved model version."
+          },
+          "splits": {
+            "description": "The split segments, in page order. Consecutive pages with the same classification merge into one segment; an identifier change starts a new segment.",
+            "items": {
+              "$ref": "#/components/schemas/Split"
+            },
+            "title": "Splits",
+            "type": "array"
+          }
+        },
+        "required": [
+          "splits",
+          "metadata"
+        ],
+        "title": "SplitResponse",
+        "type": "object"
+      },
       "TableOptions": {
         "additionalProperties": false,
         "properties": {
@@ -773,6 +928,76 @@
           "openapi_spec"
         ],
         "title": "V1BuildSchemaMetadata",
+        "type": "object"
+      },
+      "V1ClassifyMetadata": {
+        "description": "Response metadata for a classify call — VTRA's ``ClassifyMetadata``.",
+        "properties": {
+          "credit_usage": {
+            "default": 0.0,
+            "description": "Credits billed for this request.",
+            "title": "Credit Usage",
+            "type": "number"
+          },
+          "duration_ms": {
+            "description": "End-to-end request duration in milliseconds.",
+            "title": "Duration Ms",
+            "type": "integer"
+          },
+          "filename": {
+            "default": "",
+            "description": "Name of the classified file.",
+            "title": "Filename",
+            "type": "string"
+          },
+          "job_id": {
+            "default": "",
+            "description": "Gateway job id (workflow id). Matches the billing row id in vision-agent.",
+            "title": "Job Id",
+            "type": "string"
+          },
+          "openapi_spec": {
+            "description": "URL of the OpenAPI spec covering this API, for inspection and client generation.",
+            "type": "string"
+          },
+          "org_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Organization ID.",
+            "title": "Org Id"
+          },
+          "page_count": {
+            "description": "Number of pages classified.",
+            "title": "Page Count",
+            "type": "integer"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Resolved classify pipeline version that produced this response.",
+            "title": "Version"
+          }
+        },
+        "required": [
+          "page_count",
+          "duration_ms",
+          "openapi_spec"
+        ],
+        "title": "V1ClassifyMetadata",
         "type": "object"
       },
       "V1ExtractMetadata": {
@@ -1244,6 +1469,1312 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/v1/ade/classify": {
+      "post": {
+        "description": "Classify each page of a document into classes you define. Accepts a PDF, an image, or an Office document, plus the list of candidate classes; returns one predicted class per page. Runs synchronously and returns the result inline.",
+        "operationId": "v1-ade-classify_run_sync",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded\nunchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request\nbody. Mirrors VTRA's ``ClassifyRequest``.",
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document_ref": {
+                    "title": "Document Ref",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.",
+                    "title": "Model"
+                  }
+                },
+                "required": [
+                  "document_ref",
+                  "classes"
+                ],
+                "title": "ClassifyRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.",
+                    "title": "Model"
+                  }
+                },
+                "required": [
+                  "classes"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Result returned by ``V1ClassifyOperationWorkflow`` — the\n``/v1/classify`` response body (VTRA's ``ClassifyResponse``).",
+                  "properties": {
+                    "classification": {
+                      "description": "One classification result per page, in page order.",
+                      "items": {
+                        "properties": {
+                          "class": {
+                            "description": "Predicted class label, or 'unknown'.",
+                            "type": "string"
+                          },
+                          "page": {
+                            "description": "Page number, zero-indexed (the first page is 0).",
+                            "type": "integer"
+                          },
+                          "reason": {
+                            "description": "Why the page was classified this way.",
+                            "type": "string"
+                          },
+                          "suggested_class": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "description": "A class the model proposes when the prediction is 'unknown'."
+                          }
+                        },
+                        "required": [
+                          "class",
+                          "reason",
+                          "page"
+                        ],
+                        "title": "ClassificationItem",
+                        "type": "object"
+                      },
+                      "title": "Classification",
+                      "type": "array"
+                    },
+                    "metadata": {
+                      "$ref": "#/components/schemas/V1ClassifyMetadata",
+                      "description": "Metadata for the classification request."
+                    }
+                  },
+                  "required": [
+                    "classification",
+                    "metadata"
+                  ],
+                  "title": "V1ClassifyResponse",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "v1-ade-classify result"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Classify",
+        "tags": [
+          "Classify"
+        ]
+      }
+    },
+    "/v1/ade/classify/jobs": {
+      "get": {
+        "description": "List your Classify jobs, newest first.",
+        "operationId": "v1-ade-classify_list_jobs",
+        "parameters": [
+          {
+            "description": "Page number (0-indexed).",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Page number (0-indexed).",
+              "minimum": 0,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of items per page.",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Number of items per page.",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter by job status.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by job status.",
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "has_more": {
+                      "type": "boolean"
+                    },
+                    "jobs": {
+                      "items": {
+                        "properties": {
+                          "completed_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "created_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "failure_reason": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "job_id": {
+                            "description": "The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                            "type": "string"
+                          },
+                          "model_version": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "status": {
+                            "enum": [
+                              "pending",
+                              "processing",
+                              "completed",
+                              "failed"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "page_size": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The caller's jobs, newest first"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE List Classify Jobs",
+        "tags": [
+          "Classify"
+        ]
+      },
+      "post": {
+        "description": "Classify each page of a document into classes you define. Accepts a PDF, an image, or an Office document, plus the list of candidate classes; returns one predicted class per page. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.",
+        "operationId": "v1-ade-classify_create_job",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded\nunchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request\nbody. Mirrors VTRA's ``ClassifyRequest``.",
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document_ref": {
+                    "title": "Document Ref",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.",
+                    "title": "Model"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  }
+                },
+                "required": [
+                  "document_ref",
+                  "classes"
+                ],
+                "title": "ClassifyRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.",
+                    "title": "Model"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  }
+                },
+                "required": [
+                  "classes"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Classify Jobs",
+        "tags": [
+          "Classify"
+        ]
+      }
+    },
+    "/v1/ade/classify/jobs/{job_id}": {
+      "get": {
+        "description": "Get the status of an async Classify job, including its result once the job has completed.",
+        "operationId": "v1-ade-classify_get_job",
+        "parameters": [
+          {
+            "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "completed_at": {
+                      "description": "Present once the job is terminal.",
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "description": "Present once status is ``failed``.",
+                      "properties": {
+                        "code": {
+                          "description": "Stable error code (``internal_error`` when unmapped).",
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this v1-ade-classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "progress": {
+                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "result": {
+                      "anyOf": [
+                        {
+                          "description": "Result returned by ``V1ClassifyOperationWorkflow`` — the\n``/v1/classify`` response body (VTRA's ``ClassifyResponse``).",
+                          "properties": {
+                            "classification": {
+                              "description": "One classification result per page, in page order.",
+                              "items": {
+                                "properties": {
+                                  "class": {
+                                    "description": "Predicted class label, or 'unknown'.",
+                                    "type": "string"
+                                  },
+                                  "page": {
+                                    "description": "Page number, zero-indexed (the first page is 0).",
+                                    "type": "integer"
+                                  },
+                                  "reason": {
+                                    "description": "Why the page was classified this way.",
+                                    "type": "string"
+                                  },
+                                  "suggested_class": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "description": "A class the model proposes when the prediction is 'unknown'."
+                                  }
+                                },
+                                "required": [
+                                  "class",
+                                  "reason",
+                                  "page"
+                                ],
+                                "title": "ClassificationItem",
+                                "type": "object"
+                              },
+                              "title": "Classification",
+                              "type": "array"
+                            },
+                            "metadata": {
+                              "$ref": "#/components/schemas/V1ClassifyMetadata",
+                              "description": "Metadata for the classification request."
+                            }
+                          },
+                          "required": [
+                            "classification",
+                            "metadata"
+                          ],
+                          "title": "V1ClassifyResponse",
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Present once status is ``completed``."
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job status / result"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found (e.g. no such job)."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Get Classify Jobs",
+        "tags": [
+          "Classify"
+        ]
+      }
+    },
+    "/v1/ade/extract": {
+      "post": {
+        "description": "Extract structured data from a Markdown document using a JSON Schema. v1-compatible wire, running the same extraction engine as `/v2/extract`. Runs synchronously and returns the result inline.",
+        "operationId": "v1-ade-extract_run_sync",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own\nextras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on\nthe R&D ``/api/extract`` contract, so the customer surface publishes the VTRA\ncontract and only that.",
+                "properties": {
+                  "markdown": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Markdown"
+                  },
+                  "markdown_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Markdown Url"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Model"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Schema"
+                  },
+                  "strict": {
+                    "default": false,
+                    "title": "Strict",
+                    "type": "boolean"
+                  }
+                },
+                "title": "V1ExtractRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "markdown": {
+                    "description": "File upload.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "markdown_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Markdown Url"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Model"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Schema"
+                  },
+                  "strict": {
+                    "default": false,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Strict",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.\n\n``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an\n``output_ref`` instead when the payload is too large for the Temporal wire; on\nthis route that pointer is resolved back to inline content at the render\nboundary, because VTRA always inlines and a client migrating off it has no\n``output_ref`` handling at all.",
+                  "properties": {
+                    "extraction": {
+                      "additionalProperties": true,
+                      "title": "Extraction",
+                      "type": "object"
+                    },
+                    "extraction_metadata": {
+                      "additionalProperties": true,
+                      "title": "Extraction Metadata",
+                      "type": "object"
+                    },
+                    "metadata": {
+                      "$ref": "#/components/schemas/V1ExtractMetadata"
+                    }
+                  },
+                  "title": "V1ExtractResponse",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "v1-ade-extract result"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Extract",
+        "tags": [
+          "Extract"
+        ]
+      }
+    },
+    "/v1/ade/extract/jobs": {
+      "get": {
+        "description": "List your Extract jobs, newest first.",
+        "operationId": "v1-ade-extract_list_jobs",
+        "parameters": [
+          {
+            "description": "Page number (0-indexed).",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Page number (0-indexed).",
+              "minimum": 0,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of items per page.",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Number of items per page.",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter by job status.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by job status.",
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "has_more": {
+                      "type": "boolean"
+                    },
+                    "jobs": {
+                      "items": {
+                        "properties": {
+                          "completed_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "created_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "failure_reason": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "job_id": {
+                            "description": "The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                            "type": "string"
+                          },
+                          "model_version": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "status": {
+                            "enum": [
+                              "pending",
+                              "processing",
+                              "completed",
+                              "failed"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "page_size": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The caller's jobs, newest first"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE List Extract Jobs",
+        "tags": [
+          "Extract"
+        ]
+      },
+      "post": {
+        "description": "Extract structured data from a Markdown document using a JSON Schema. v1-compatible wire, running the same extraction engine as `/v2/extract`. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.",
+        "operationId": "v1-ade-extract_create_job",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own\nextras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on\nthe R&D ``/api/extract`` contract, so the customer surface publishes the VTRA\ncontract and only that.",
+                "properties": {
+                  "markdown": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Markdown"
+                  },
+                  "markdown_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Markdown Url"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Model"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Schema"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  },
+                  "strict": {
+                    "default": false,
+                    "title": "Strict",
+                    "type": "boolean"
+                  }
+                },
+                "title": "V1ExtractRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "markdown": {
+                    "description": "File upload.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "markdown_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Markdown Url"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Model"
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Schema"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  },
+                  "strict": {
+                    "default": false,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Strict",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Extract Jobs",
+        "tags": [
+          "Extract"
+        ]
+      }
+    },
+    "/v1/ade/extract/jobs/{job_id}": {
+      "get": {
+        "description": "Get the status of an async Extract job, including its result once the job has completed.",
+        "operationId": "v1-ade-extract_get_job",
+        "parameters": [
+          {
+            "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "completed_at": {
+                      "description": "Present once the job is terminal.",
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "description": "Present once status is ``failed``.",
+                      "properties": {
+                        "code": {
+                          "description": "Stable error code (``internal_error`` when unmapped).",
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "progress": {
+                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "result": {
+                      "anyOf": [
+                        {
+                          "description": "VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.\n\n``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an\n``output_ref`` instead when the payload is too large for the Temporal wire; on\nthis route that pointer is resolved back to inline content at the render\nboundary, because VTRA always inlines and a client migrating off it has no\n``output_ref`` handling at all.",
+                          "properties": {
+                            "extraction": {
+                              "additionalProperties": true,
+                              "title": "Extraction",
+                              "type": "object"
+                            },
+                            "extraction_metadata": {
+                              "additionalProperties": true,
+                              "title": "Extraction Metadata",
+                              "type": "object"
+                            },
+                            "metadata": {
+                              "$ref": "#/components/schemas/V1ExtractMetadata"
+                            }
+                          },
+                          "title": "V1ExtractResponse",
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Present once status is ``completed``."
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job status / result"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found (e.g. no such job)."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Get Extract Jobs",
+        "tags": [
+          "Extract"
+        ]
+      }
+    },
     "/v1/ade/parse": {
       "post": {
         "description": "Run synchronously and return the result inline.\n\nAccepts ``application/json`` (the request fields as the body),\n``multipart/form-data`` (file fields are staged automatically),\nor ``application/x-www-form-urlencoded`` (text fields only).\n\nReturns **504** if the work does not finish within the wait\nwindow — long-running work belongs on the async ``POST\n{path}/jobs`` route, which returns 202 immediately and is polled\nvia ``GET {path}/jobs/{job_id}``. On a 504 the workflow is\nCANCELLED (a sync caller can never collect the result); a retry\nstarts the work over as a fresh job.",
@@ -1399,9 +2930,13 @@
                     "description": "JSON-serialized string in form data.",
                     "title": "Custom Prompts"
                   },
-                  "document_ref": {
-                    "description": "File upload.",
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
                     "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
                     "type": "string"
                   },
                   "filename": {
@@ -1502,7 +3037,6 @@
                   }
                 },
                 "required": [
-                  "document_ref",
                   "filename",
                   "content_type"
                 ],
@@ -1528,6 +3062,11 @@
                       "default": 0,
                       "title": "Billable Pages",
                       "type": "integer"
+                    },
+                    "billing_suppressed": {
+                      "default": false,
+                      "title": "Billing Suppressed",
+                      "type": "boolean"
                     },
                     "completion_tokens": {
                       "default": 0,
@@ -1968,9 +3507,13 @@
                     "description": "JSON-serialized string in form data.",
                     "title": "Custom Prompts"
                   },
-                  "document_ref": {
-                    "description": "File upload.",
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
                     "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
                     "type": "string"
                   },
                   "filename": {
@@ -2099,7 +3642,6 @@
                   }
                 },
                 "required": [
-                  "document_ref",
                   "filename",
                   "content_type"
                 ],
@@ -2242,6 +3784,11 @@
                               "default": 0,
                               "title": "Billable Pages",
                               "type": "integer"
+                            },
+                            "billing_suppressed": {
+                              "default": false,
+                              "title": "Billing Suppressed",
+                              "type": "boolean"
                             },
                             "completion_tokens": {
                               "default": 0,
@@ -2397,39 +3944,37 @@
         ]
       }
     },
-    "/v1/extract": {
+    "/v1/classify": {
       "post": {
-        "description": "Extract structured data from a Markdown document using a JSON Schema. v1-compatible wire, running the same extraction engine as `/v2/extract`. Runs synchronously and returns the result inline.",
-        "operationId": "v1-extract_run_sync",
+        "description": "Classify each page of a document into classes you define. Accepts a PDF, an image, or an Office document, plus the list of candidate classes; returns one predicted class per page. Runs synchronously and returns the result inline.",
+        "operationId": "classify_run_sync",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own\nextras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on\nthe R&D ``/api/extract`` contract, so the customer surface publishes the VTRA\ncontract and only that.",
+                "description": "Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded\nunchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request\nbody. Mirrors VTRA's ``ClassifyRequest``.",
                 "properties": {
-                  "markdown": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Markdown"
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
                   },
-                  "markdown_url": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Markdown Url"
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document_ref": {
+                    "title": "Document Ref",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
                   },
                   "model": {
                     "anyOf": [
@@ -2441,50 +3986,47 @@
                       }
                     ],
                     "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.",
                     "title": "Model"
-                  },
-                  "schema": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Schema"
-                  },
-                  "strict": {
-                    "default": false,
-                    "title": "Strict",
-                    "type": "boolean"
                   }
                 },
-                "title": "V1ExtractRequest",
+                "required": [
+                  "document_ref",
+                  "classes"
+                ],
+                "title": "ClassifyRequest",
                 "type": "object"
               }
             },
             "multipart/form-data": {
               "schema": {
                 "properties": {
-                  "markdown": {
-                    "description": "File upload.",
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
                     "format": "binary",
                     "type": "string"
                   },
-                  "markdown_url": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Markdown Url"
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
                   },
                   "model": {
                     "anyOf": [
@@ -2496,29 +4038,13 @@
                       }
                     ],
                     "default": null,
-                    "description": "JSON-serialized string in form data.",
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.",
                     "title": "Model"
-                  },
-                  "schema": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Schema"
-                  },
-                  "strict": {
-                    "default": false,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Strict",
-                    "type": "boolean"
                   }
                 },
+                "required": [
+                  "classes"
+                ],
                 "type": "object"
               }
             }
@@ -2530,28 +4056,62 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "description": "VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.\n\n``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an\n``output_ref`` instead when the payload is too large for the Temporal wire; on\nthis route that pointer is resolved back to inline content at the render\nboundary, because VTRA always inlines and a client migrating off it has no\n``output_ref`` handling at all.",
+                  "description": "Result returned by ``V1ClassifyOperationWorkflow`` — the\n``/v1/classify`` response body (VTRA's ``ClassifyResponse``).",
                   "properties": {
-                    "extraction": {
-                      "additionalProperties": true,
-                      "title": "Extraction",
-                      "type": "object"
-                    },
-                    "extraction_metadata": {
-                      "additionalProperties": true,
-                      "title": "Extraction Metadata",
-                      "type": "object"
+                    "classification": {
+                      "description": "One classification result per page, in page order.",
+                      "items": {
+                        "properties": {
+                          "class": {
+                            "description": "Predicted class label, or 'unknown'.",
+                            "type": "string"
+                          },
+                          "page": {
+                            "description": "Page number, zero-indexed (the first page is 0).",
+                            "type": "integer"
+                          },
+                          "reason": {
+                            "description": "Why the page was classified this way.",
+                            "type": "string"
+                          },
+                          "suggested_class": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "description": "A class the model proposes when the prediction is 'unknown'."
+                          }
+                        },
+                        "required": [
+                          "class",
+                          "reason",
+                          "page"
+                        ],
+                        "title": "ClassificationItem",
+                        "type": "object"
+                      },
+                      "title": "Classification",
+                      "type": "array"
                     },
                     "metadata": {
-                      "$ref": "#/components/schemas/V1ExtractMetadata"
+                      "$ref": "#/components/schemas/V1ClassifyMetadata",
+                      "description": "Metadata for the classification request."
                     }
                   },
-                  "title": "V1ExtractResponse",
+                  "required": [
+                    "classification",
+                    "metadata"
+                  ],
+                  "title": "V1ClassifyResponse",
                   "type": "object"
                 }
               }
             },
-            "description": "v1-extract result"
+            "description": "classify result"
           },
           "422": {
             "content": {
@@ -2564,9 +4124,489 @@
             "description": "Request validation failed."
           }
         },
-        "summary": "ADE Extract",
+        "summary": "ADE Classify",
         "tags": [
-          "Extract"
+          "Classify"
+        ]
+      }
+    },
+    "/v1/classify/jobs": {
+      "get": {
+        "description": "List your Classify jobs, newest first.",
+        "operationId": "classify_list_jobs",
+        "parameters": [
+          {
+            "description": "Page number (0-indexed).",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Page number (0-indexed).",
+              "minimum": 0,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of items per page.",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "description": "Number of items per page.",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter by job status.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by job status.",
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "has_more": {
+                      "type": "boolean"
+                    },
+                    "jobs": {
+                      "items": {
+                        "properties": {
+                          "completed_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "created_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "failure_reason": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "job_id": {
+                            "description": "The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                            "type": "string"
+                          },
+                          "model_version": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "status": {
+                            "enum": [
+                              "pending",
+                              "processing",
+                              "completed",
+                              "failed"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "page_size": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The caller's jobs, newest first"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE List Classify Jobs",
+        "tags": [
+          "Classify"
+        ]
+      },
+      "post": {
+        "description": "Classify each page of a document into classes you define. Accepts a PDF, an image, or an Office document, plus the list of candidate classes; returns one predicted class per page. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.",
+        "operationId": "classify_create_job",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Input to ``V1ClassifyOperationWorkflow`` (gateway) and, threaded\nunchanged, to ``ClassifyWorkflow`` (work) — the ``/v1/classify`` request\nbody. Mirrors VTRA's ``ClassifyRequest``.",
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document_ref": {
+                    "title": "Document Ref",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version.",
+                    "title": "Model"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  }
+                },
+                "required": [
+                  "document_ref",
+                  "classes"
+                ],
+                "title": "ClassifyRequest",
+                "type": "object"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "classes": {
+                    "description": "The possible classes that can be assigned to pages in the document. Each entry is an object with a `class` name and an optional `description`. Only one class is assigned per page; unclassifiable pages receive 'unknown'. On a multipart request this is a JSON string. JSON-serialized string in form data.",
+                    "items": {
+                      "$ref": "#/components/schemas/ClassifyClass"
+                    },
+                    "title": "Classes",
+                    "type": "array"
+                  },
+                  "content_type": {
+                    "default": "",
+                    "title": "Content Type",
+                    "type": "string"
+                  },
+                  "document": {
+                    "description": "The file to process. Provide either `document` or `document_url`, not both.",
+                    "format": "binary",
+                    "type": "string"
+                  },
+                  "document_url": {
+                    "description": "A publicly accessible URL to the file to process. Provide either `document` or `document_url`, not both.",
+                    "type": "string"
+                  },
+                  "filename": {
+                    "default": "",
+                    "title": "Filename",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Classify pipeline version, e.g. `classify-20260420`. Accepts `classify-latest`. Defaults to the latest version. JSON-serialized string in form data.",
+                    "title": "Model"
+                  },
+                  "service_tier": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "standard",
+                          "priority"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
+                  }
+                },
+                "required": [
+                  "classes"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job created"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Classify Jobs",
+        "tags": [
+          "Classify"
+        ]
+      }
+    },
+    "/v1/classify/jobs/{job_id}": {
+      "get": {
+        "description": "Get the status of an async Classify job, including its result once the job has completed.",
+        "operationId": "classify_get_job",
+        "parameters": [
+          {
+            "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "description": "The identifier of the job to retrieve, as returned by the create-job request.",
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "completed_at": {
+                      "description": "Present once the job is terminal.",
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "description": "Present once status is ``failed``.",
+                      "properties": {
+                        "code": {
+                          "description": "Stable error code (``internal_error`` when unmapped).",
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "job_id": {
+                      "description": "The unique identifier for this classify job. Format: ``classify-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
+                      "type": "string"
+                    },
+                    "progress": {
+                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "result": {
+                      "anyOf": [
+                        {
+                          "description": "Result returned by ``V1ClassifyOperationWorkflow`` — the\n``/v1/classify`` response body (VTRA's ``ClassifyResponse``).",
+                          "properties": {
+                            "classification": {
+                              "description": "One classification result per page, in page order.",
+                              "items": {
+                                "properties": {
+                                  "class": {
+                                    "description": "Predicted class label, or 'unknown'.",
+                                    "type": "string"
+                                  },
+                                  "page": {
+                                    "description": "Page number, zero-indexed (the first page is 0).",
+                                    "type": "integer"
+                                  },
+                                  "reason": {
+                                    "description": "Why the page was classified this way.",
+                                    "type": "string"
+                                  },
+                                  "suggested_class": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "description": "A class the model proposes when the prediction is 'unknown'."
+                                  }
+                                },
+                                "required": [
+                                  "class",
+                                  "reason",
+                                  "page"
+                                ],
+                                "title": "ClassificationItem",
+                                "type": "object"
+                              },
+                              "title": "Classification",
+                              "type": "array"
+                            },
+                            "metadata": {
+                              "$ref": "#/components/schemas/V1ClassifyMetadata",
+                              "description": "Metadata for the classification request."
+                            }
+                          },
+                          "required": [
+                            "classification",
+                            "metadata"
+                          ],
+                          "title": "V1ClassifyResponse",
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Present once status is ``completed``."
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "processing",
+                        "completed",
+                        "failed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job status / result"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found (e.g. no such job)."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request validation failed."
+          }
+        },
+        "summary": "ADE Get Classify Jobs",
+        "tags": [
+          "Classify"
         ]
       }
     },
@@ -3290,734 +5330,42 @@
         ]
       }
     },
-    "/v1/extract/jobs": {
-      "get": {
-        "description": "List your Extract jobs, newest first.",
-        "operationId": "v1-extract_list_jobs",
-        "parameters": [
-          {
-            "description": "Page number (0-indexed).",
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "schema": {
-              "default": 0,
-              "description": "Page number (0-indexed).",
-              "minimum": 0,
-              "title": "Page",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Number of items per page.",
-            "in": "query",
-            "name": "page_size",
-            "required": false,
-            "schema": {
-              "default": 10,
-              "description": "Number of items per page.",
-              "maximum": 100,
-              "minimum": 1,
-              "title": "Page Size",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Filter by job status.",
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Filter by job status.",
-              "title": "Status"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "has_more": {
-                      "type": "boolean"
-                    },
-                    "jobs": {
-                      "items": {
-                        "properties": {
-                          "completed_at": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "created_at": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "failure_reason": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "job_id": {
-                            "description": "The unique identifier for this v1-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                            "type": "string"
-                          },
-                          "model_version": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "status": {
-                            "enum": [
-                              "pending",
-                              "processing",
-                              "completed",
-                              "failed"
-                            ],
-                            "type": "string"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "type": "array"
-                    },
-                    "page": {
-                      "type": "integer"
-                    },
-                    "page_size": {
-                      "type": "integer"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "The caller's jobs, newest first"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE List Extract Jobs",
-        "tags": [
-          "Extract"
-        ]
-      },
+    "/v1/split": {
       "post": {
-        "description": "Extract structured data from a Markdown document using a JSON Schema. v1-compatible wire, running the same extraction engine as `/v2/extract`. Runs asynchronously and returns a job ID; use it to poll for status and retrieve the result once processing completes.",
-        "operationId": "v1-extract_create_job",
+        "description": "Split a Markdown document into segments and return the split response inline.",
+        "operationId": "v1-split_run_sync",
         "requestBody": {
           "content": {
-            "application/json": {
-              "schema": {
-                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own\nextras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on\nthe R&D ``/api/extract`` contract, so the customer surface publishes the VTRA\ncontract and only that.",
-                "properties": {
-                  "markdown": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Markdown"
-                  },
-                  "markdown_url": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Markdown Url"
-                  },
-                  "model": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Model"
-                  },
-                  "schema": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Schema"
-                  },
-                  "service_tier": {
-                    "anyOf": [
-                      {
-                        "enum": [
-                          "standard",
-                          "priority"
-                        ],
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
-                  },
-                  "strict": {
-                    "default": false,
-                    "title": "Strict",
-                    "type": "boolean"
-                  }
-                },
-                "title": "V1ExtractRequest",
-                "type": "object"
-              }
-            },
             "multipart/form-data": {
               "schema": {
                 "properties": {
                   "markdown": {
-                    "description": "File upload.",
-                    "format": "binary",
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "format": "binary",
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "Markdown content to split, as an inline string or an uploaded file. Provide either `markdown` or `markdown_url`, not both."
                   },
                   "markdown_url": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Markdown Url"
+                    "description": "A publicly accessible URL to the Markdown file to split. Provide either `markdown` or `markdown_url`, not both.",
+                    "type": "string"
                   },
                   "model": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Model"
-                  },
-                  "schema": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Schema"
-                  },
-                  "service_tier": {
-                    "anyOf": [
-                      {
-                        "enum": [
-                          "standard",
-                          "priority"
-                        ],
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
-                  },
-                  "strict": {
-                    "default": false,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Strict",
-                    "type": "boolean"
-                  }
-                },
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "created_at": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "job_id": {
-                      "description": "The unique identifier for this v1-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                      "type": "string"
-                    },
-                    "status": {
-                      "enum": [
-                        "pending",
-                        "processing",
-                        "completed",
-                        "failed"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Job created"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE Extract Jobs",
-        "tags": [
-          "Extract"
-        ]
-      }
-    },
-    "/v1/extract/jobs/{job_id}": {
-      "get": {
-        "description": "Get the status of an async Extract job, including its result once the job has completed.",
-        "operationId": "v1-extract_get_job",
-        "parameters": [
-          {
-            "description": "The identifier of the job to retrieve, as returned by the create-job request.",
-            "in": "path",
-            "name": "job_id",
-            "required": true,
-            "schema": {
-              "description": "The identifier of the job to retrieve, as returned by the create-job request.",
-              "title": "Job Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "completed_at": {
-                      "description": "Present once the job is terminal.",
-                      "type": "string"
-                    },
-                    "created_at": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "error": {
-                      "description": "Present once status is ``failed``.",
-                      "properties": {
-                        "code": {
-                          "description": "Stable error code (``internal_error`` when unmapped).",
-                          "type": "string"
-                        },
-                        "message": {
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "job_id": {
-                      "description": "The unique identifier for this v1-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                      "type": "string"
-                    },
-                    "progress": {
-                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
-                      "maximum": 1,
-                      "minimum": 0,
-                      "type": "number"
-                    },
-                    "result": {
-                      "anyOf": [
-                        {
-                          "description": "VTRA's ``ExtractResponse`` — the ``/v1/extract`` response body.\n\n``extraction`` is ALWAYS inline. The internal ``ExtractResult`` returns an\n``output_ref`` instead when the payload is too large for the Temporal wire; on\nthis route that pointer is resolved back to inline content at the render\nboundary, because VTRA always inlines and a client migrating off it has no\n``output_ref`` handling at all.",
-                          "properties": {
-                            "extraction": {
-                              "additionalProperties": true,
-                              "title": "Extraction",
-                              "type": "object"
-                            },
-                            "extraction_metadata": {
-                              "additionalProperties": true,
-                              "title": "Extraction Metadata",
-                              "type": "object"
-                            },
-                            "metadata": {
-                              "$ref": "#/components/schemas/V1ExtractMetadata"
-                            }
-                          },
-                          "title": "V1ExtractResponse",
-                          "type": "object"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "description": "Present once status is ``completed``."
-                    },
-                    "status": {
-                      "enum": [
-                        "pending",
-                        "processing",
-                        "completed",
-                        "failed"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Job status / result"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Not found (e.g. no such job)."
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE Get Extract Jobs",
-        "tags": [
-          "Extract"
-        ]
-      }
-    },
-    "/v1/parse": {
-      "post": {
-        "description": "Run synchronously and return the result inline.\n\nAccepts ``application/json`` (the request fields as the body),\n``multipart/form-data`` (file fields are staged automatically),\nor ``application/x-www-form-urlencoded`` (text fields only).\n\nReturns **504** if the work does not finish within the wait\nwindow — long-running work belongs on the async ``POST\n{path}/jobs`` route, which returns 202 immediately and is polled\nvia ``GET {path}/jobs/{job_id}``. On a 504 the workflow is\nCANCELLED (a sync caller can never collect the result); a retry\nstarts the work over as a fresh job.",
-        "operationId": "parse2_run_sync",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "description": "Input to ``Parse2OperationWorkflow`` (gateway) and ``Parse2DocumentWorkflow``\n(work). The document rides as ``document_ref`` (the gateway's multipart adapter\nstages the upload / fetches ``document_url`` → data store, runs the pdf_pages\npre-flight, then starts the operation).",
-                "properties": {
-                  "content_type": {
-                    "title": "Content Type",
+                    "description": "The split model version to use. Accepts a dated snapshot (`split-20251105`), `split-latest`, or `split` (both aliases resolve to the latest snapshot). Defaults to the latest snapshot. The resolved version is echoed back as `metadata.version`.",
                     "type": "string"
                   },
-                  "custom_prompts": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Custom Prompts"
-                  },
-                  "document_ref": {
-                    "title": "Document Ref",
+                  "split_class": {
+                    "description": "The split classification entries, as a JSON-encoded array of objects with `name` (required), `description`, and `identifier` keys. At most 19 entries. Sent as a JSON-serialized string in form data.",
                     "type": "string"
-                  },
-                  "filename": {
-                    "title": "Filename",
-                    "type": "string"
-                  },
-                  "job_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Job Id"
-                  },
-                  "model_versions": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Model Versions"
-                  },
-                  "password": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Password"
-                  },
-                  "pricing_multiplier": {
-                    "default": 1.0,
-                    "title": "Pricing Multiplier",
-                    "type": "number"
-                  },
-                  "processing_mode": {
-                    "default": "sync",
-                    "title": "Processing Mode",
-                    "type": "string"
-                  },
-                  "split": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Split"
-                  },
-                  "version": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Version"
-                  },
-                  "x_request_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "X Request Id"
                   }
                 },
                 "required": [
-                  "document_ref",
-                  "filename",
-                  "content_type"
-                ],
-                "title": "Parse2Request",
-                "type": "object"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "properties": {
-                  "content_type": {
-                    "title": "Content Type",
-                    "type": "string"
-                  },
-                  "custom_prompts": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Custom Prompts"
-                  },
-                  "document_ref": {
-                    "description": "File upload.",
-                    "format": "binary",
-                    "type": "string"
-                  },
-                  "filename": {
-                    "title": "Filename",
-                    "type": "string"
-                  },
-                  "job_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Job Id"
-                  },
-                  "model_versions": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Model Versions"
-                  },
-                  "password": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Password"
-                  },
-                  "pricing_multiplier": {
-                    "default": 1.0,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Pricing Multiplier",
-                    "type": "number"
-                  },
-                  "processing_mode": {
-                    "default": "sync",
-                    "title": "Processing Mode",
-                    "type": "string"
-                  },
-                  "split": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Split"
-                  },
-                  "version": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Version"
-                  },
-                  "x_request_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "X Request Id"
-                  }
-                },
-                "required": [
-                  "document_ref",
-                  "filename",
-                  "content_type"
+                  "split_class"
                 ],
                 "type": "object"
               }
@@ -4030,126 +5378,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "description": "Output of ``Parse2DocumentWorkflow``. Carries the customer response plus the\nbilling inputs hoisted to the top level so the gateway operation reads them\nwithout re-parsing the nested tree.\n\nBilling is worker-owned (parse-api parity): the worker finalizes the price and\nreports it on the standard ``credit_usage: CreditUsage`` shape (``credits`` =\nFINAL billed value, ``charge_unit`` = billable pages, ``breakdown`` = itemized),\nplus the record-inference enrichment (``usage`` + ``model_family``). The\ngateway's default biller reads ``credit_usage`` verbatim (a ``JobContract.billed()``\nop — no gateway recomputation).",
-                  "properties": {
-                    "base_credit": {
-                      "default": 0.0,
-                      "title": "Base Credit",
-                      "type": "number"
-                    },
-                    "billable_pages": {
-                      "default": 0,
-                      "title": "Billable Pages",
-                      "type": "integer"
-                    },
-                    "completion_tokens": {
-                      "default": 0,
-                      "title": "Completion Tokens",
-                      "type": "integer"
-                    },
-                    "credit_usage": {
-                      "$ref": "#/components/schemas/CreditUsage"
-                    },
-                    "duration_ms": {
-                      "default": 0,
-                      "title": "Duration Ms",
-                      "type": "integer"
-                    },
-                    "failed_pages": {
-                      "items": {
-                        "type": "integer"
-                      },
-                      "title": "Failed Pages",
-                      "type": "array"
-                    },
-                    "model_family": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Model Family"
-                    },
-                    "output_ref": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Output Ref"
-                    },
-                    "page_count": {
-                      "default": 0,
-                      "title": "Page Count",
-                      "type": "integer"
-                    },
-                    "prompt_tokens": {
-                      "default": 0,
-                      "title": "Prompt Tokens",
-                      "type": "integer"
-                    },
-                    "response": {
-                      "additionalProperties": true,
-                      "title": "Response",
-                      "type": "object"
-                    },
-                    "status_code": {
-                      "default": 200,
-                      "title": "Status Code",
-                      "type": "integer"
-                    },
-                    "token_steps": {
-                      "anyOf": [
-                        {
-                          "items": {
-                            "additionalProperties": true,
-                            "type": "object"
-                          },
-                          "type": "array"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Token Steps"
-                    },
-                    "total_tokens": {
-                      "default": 0,
-                      "title": "Total Tokens",
-                      "type": "integer"
-                    },
-                    "usage": {
-                      "anyOf": [
-                        {
-                          "additionalProperties": true,
-                          "type": "object"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "default": null,
-                      "title": "Usage"
-                    }
-                  },
-                  "required": [
-                    "response"
-                  ],
-                  "title": "Parse2Result",
-                  "type": "object"
+                  "$ref": "#/components/schemas/SplitResponse"
                 }
               }
             },
-            "description": "parse2 result"
+            "description": "The split response"
           },
           "422": {
             "content": {
@@ -4162,751 +5395,9 @@
             "description": "Request validation failed."
           }
         },
-        "summary": "ADE Parse v1",
+        "summary": "ADE Split",
         "tags": [
-          "Parse v1"
-        ]
-      }
-    },
-    "/v1/parse/jobs": {
-      "get": {
-        "operationId": "parse2_list_jobs",
-        "parameters": [
-          {
-            "description": "Page number (0-indexed).",
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "schema": {
-              "default": 0,
-              "description": "Page number (0-indexed).",
-              "minimum": 0,
-              "title": "Page",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Number of items per page.",
-            "in": "query",
-            "name": "page_size",
-            "required": false,
-            "schema": {
-              "default": 10,
-              "description": "Number of items per page.",
-              "maximum": 100,
-              "minimum": 1,
-              "title": "Page Size",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Filter by job status.",
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Filter by job status.",
-              "title": "Status"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "has_more": {
-                      "type": "boolean"
-                    },
-                    "jobs": {
-                      "items": {
-                        "properties": {
-                          "completed_at": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "created_at": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "failure_reason": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "job_id": {
-                            "description": "The unique identifier for this parse2 job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                            "type": "string"
-                          },
-                          "model_version": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "status": {
-                            "enum": [
-                              "pending",
-                              "processing",
-                              "completed",
-                              "failed"
-                            ],
-                            "type": "string"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "type": "array"
-                    },
-                    "page": {
-                      "type": "integer"
-                    },
-                    "page_size": {
-                      "type": "integer"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "The caller's jobs, newest first"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE List Parse v1 Jobs",
-        "tags": [
-          "Parse v1"
-        ]
-      },
-      "post": {
-        "operationId": "parse2_create_job",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "description": "Input to ``Parse2OperationWorkflow`` (gateway) and ``Parse2DocumentWorkflow``\n(work). The document rides as ``document_ref`` (the gateway's multipart adapter\nstages the upload / fetches ``document_url`` → data store, runs the pdf_pages\npre-flight, then starts the operation).",
-                "properties": {
-                  "content_type": {
-                    "title": "Content Type",
-                    "type": "string"
-                  },
-                  "custom_prompts": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Custom Prompts"
-                  },
-                  "document_ref": {
-                    "title": "Document Ref",
-                    "type": "string"
-                  },
-                  "filename": {
-                    "title": "Filename",
-                    "type": "string"
-                  },
-                  "job_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Job Id"
-                  },
-                  "model_versions": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Model Versions"
-                  },
-                  "output_save_url": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Output Save Url"
-                  },
-                  "password": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Password"
-                  },
-                  "pricing_multiplier": {
-                    "default": 1.0,
-                    "title": "Pricing Multiplier",
-                    "type": "number"
-                  },
-                  "processing_mode": {
-                    "default": "sync",
-                    "title": "Processing Mode",
-                    "type": "string"
-                  },
-                  "service_tier": {
-                    "anyOf": [
-                      {
-                        "enum": [
-                          "standard",
-                          "priority"
-                        ],
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
-                  },
-                  "split": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Split"
-                  },
-                  "version": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Version"
-                  },
-                  "x_request_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "X Request Id"
-                  }
-                },
-                "required": [
-                  "document_ref",
-                  "filename",
-                  "content_type"
-                ],
-                "title": "Parse2Request",
-                "type": "object"
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "properties": {
-                  "content_type": {
-                    "title": "Content Type",
-                    "type": "string"
-                  },
-                  "custom_prompts": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Custom Prompts"
-                  },
-                  "document_ref": {
-                    "description": "File upload.",
-                    "format": "binary",
-                    "type": "string"
-                  },
-                  "filename": {
-                    "title": "Filename",
-                    "type": "string"
-                  },
-                  "job_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Job Id"
-                  },
-                  "model_versions": {
-                    "anyOf": [
-                      {
-                        "additionalProperties": {
-                          "type": "string"
-                        },
-                        "type": "object"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Model Versions"
-                  },
-                  "output_save_url": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Output Save Url"
-                  },
-                  "password": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Password"
-                  },
-                  "pricing_multiplier": {
-                    "default": 1.0,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Pricing Multiplier",
-                    "type": "number"
-                  },
-                  "processing_mode": {
-                    "default": "sync",
-                    "title": "Processing Mode",
-                    "type": "string"
-                  },
-                  "service_tier": {
-                    "anyOf": [
-                      {
-                        "enum": [
-                          "standard",
-                          "priority"
-                        ],
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "description": "Async service tier. ``priority`` runs in the fast lane at the sync billing rate; absent → ``standard``."
-                  },
-                  "split": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Split"
-                  },
-                  "version": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "Version"
-                  },
-                  "x_request_id": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "description": "JSON-serialized string in form data.",
-                    "title": "X Request Id"
-                  }
-                },
-                "required": [
-                  "document_ref",
-                  "filename",
-                  "content_type"
-                ],
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "202": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "created_at": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "job_id": {
-                      "description": "The unique identifier for this parse2 job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                      "type": "string"
-                    },
-                    "status": {
-                      "enum": [
-                        "pending",
-                        "processing",
-                        "completed",
-                        "failed"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Job created"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE Parse v1 Jobs",
-        "tags": [
-          "Parse v1"
-        ]
-      }
-    },
-    "/v1/parse/jobs/{job_id}": {
-      "get": {
-        "description": "Poll a job.\n\nReturns ``{job_id, status, created_at}`` plus ``completed_at`` and\n``result`` (on ``completed``) or ``error: {code, message}`` (on\n``failed``). Statuses: ``pending`` → ``processing`` →\n``completed`` | ``failed``.",
-        "operationId": "parse2_get_job",
-        "parameters": [
-          {
-            "description": "The identifier of the job to retrieve, as returned by the create-job request.",
-            "in": "path",
-            "name": "job_id",
-            "required": true,
-            "schema": {
-              "description": "The identifier of the job to retrieve, as returned by the create-job request.",
-              "title": "Job Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "completed_at": {
-                      "description": "Present once the job is terminal.",
-                      "type": "string"
-                    },
-                    "created_at": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "error": {
-                      "description": "Present once status is ``failed``.",
-                      "properties": {
-                        "code": {
-                          "description": "Stable error code (``internal_error`` when unmapped).",
-                          "type": "string"
-                        },
-                        "message": {
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "job_id": {
-                      "description": "The unique identifier for this parse2 job. Format: ``parse2-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
-                      "type": "string"
-                    },
-                    "metadata": {
-                      "description": "The result's metadata block (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Same shape as the inline ``result``'s ``metadata``; inline jobs carry it there instead.",
-                      "type": [
-                        "object",
-                        "null"
-                      ]
-                    },
-                    "output_url": {
-                      "description": "The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``.",
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "progress": {
-                      "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
-                      "maximum": 1,
-                      "minimum": 0,
-                      "type": "number"
-                    },
-                    "result": {
-                      "anyOf": [
-                        {
-                          "description": "Output of ``Parse2DocumentWorkflow``. Carries the customer response plus the\nbilling inputs hoisted to the top level so the gateway operation reads them\nwithout re-parsing the nested tree.\n\nBilling is worker-owned (parse-api parity): the worker finalizes the price and\nreports it on the standard ``credit_usage: CreditUsage`` shape (``credits`` =\nFINAL billed value, ``charge_unit`` = billable pages, ``breakdown`` = itemized),\nplus the record-inference enrichment (``usage`` + ``model_family``). The\ngateway's default biller reads ``credit_usage`` verbatim (a ``JobContract.billed()``\nop — no gateway recomputation).",
-                          "properties": {
-                            "base_credit": {
-                              "default": 0.0,
-                              "title": "Base Credit",
-                              "type": "number"
-                            },
-                            "billable_pages": {
-                              "default": 0,
-                              "title": "Billable Pages",
-                              "type": "integer"
-                            },
-                            "completion_tokens": {
-                              "default": 0,
-                              "title": "Completion Tokens",
-                              "type": "integer"
-                            },
-                            "credit_usage": {
-                              "$ref": "#/components/schemas/CreditUsage"
-                            },
-                            "duration_ms": {
-                              "default": 0,
-                              "title": "Duration Ms",
-                              "type": "integer"
-                            },
-                            "failed_pages": {
-                              "items": {
-                                "type": "integer"
-                              },
-                              "title": "Failed Pages",
-                              "type": "array"
-                            },
-                            "model_family": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ],
-                              "default": null,
-                              "title": "Model Family"
-                            },
-                            "output_ref": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ],
-                              "default": null,
-                              "title": "Output Ref"
-                            },
-                            "page_count": {
-                              "default": 0,
-                              "title": "Page Count",
-                              "type": "integer"
-                            },
-                            "prompt_tokens": {
-                              "default": 0,
-                              "title": "Prompt Tokens",
-                              "type": "integer"
-                            },
-                            "response": {
-                              "additionalProperties": true,
-                              "title": "Response",
-                              "type": "object"
-                            },
-                            "status_code": {
-                              "default": 200,
-                              "title": "Status Code",
-                              "type": "integer"
-                            },
-                            "token_steps": {
-                              "anyOf": [
-                                {
-                                  "items": {
-                                    "additionalProperties": true,
-                                    "type": "object"
-                                  },
-                                  "type": "array"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ],
-                              "default": null,
-                              "title": "Token Steps"
-                            },
-                            "total_tokens": {
-                              "default": 0,
-                              "title": "Total Tokens",
-                              "type": "integer"
-                            },
-                            "usage": {
-                              "anyOf": [
-                                {
-                                  "additionalProperties": true,
-                                  "type": "object"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ],
-                              "default": null,
-                              "title": "Usage"
-                            }
-                          },
-                          "required": [
-                            "response"
-                          ],
-                          "title": "Parse2Result",
-                          "type": "object"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ],
-                      "description": "Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead."
-                    },
-                    "status": {
-                      "enum": [
-                        "pending",
-                        "processing",
-                        "completed",
-                        "failed"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Job status / result"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Not found (e.g. no such job)."
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request validation failed."
-          }
-        },
-        "summary": "ADE Get Parse v1 Jobs",
-        "tags": [
-          "Parse v1"
+          "Split"
         ]
       }
     },
@@ -5961,7 +6452,7 @@
                           }
                         ],
                         "default": null,
-                        "description": "Password for encrypted PDFs. Not currently supported — providing a value returns a 422 error; decrypt the file before uploading.",
+                        "description": "Password for an encrypted PDF. The document is decrypted once at the start of processing; the password is not retained with the result. PDFs only — supplying one for an image or Office document returns a 422 (`password_unsupported_content_type`). A wrong password returns a 422 (`encrypted_pdf_wrong_password`); omitting it for a locked PDF returns a 422 (`encrypted_pdf_password_required`).",
                         "title": "Password"
                       }
                     },
@@ -6220,7 +6711,7 @@
                           }
                         ],
                         "default": null,
-                        "description": "Password for encrypted PDFs. Not currently supported — providing a value returns a 422 error; decrypt the file before uploading.",
+                        "description": "Password for an encrypted PDF. The document is decrypted once at the start of processing; the password is not retained with the result. PDFs only — supplying one for an image or Office document returns a 422 (`password_unsupported_content_type`). A wrong password returns a 422 (`encrypted_pdf_wrong_password`); omitting it for a locked PDF returns a 422 (`encrypted_pdf_password_required`).",
                         "title": "Password"
                       }
                     },

--- a/src/resources/v2/parse.ts
+++ b/src/resources/v2/parse.ts
@@ -34,8 +34,12 @@ export interface V2ParseParams {
   options?: Record<string, unknown> | string | null;
 
   /**
-   * Encrypted PDFs are not currently supported: providing a password returns a
-   * 422. Decrypt the file before uploading. Sent within `options` on the wire.
+   * Password for an encrypted PDF. The document is decrypted once at the start
+   * of processing, and the password is not retained with the result. PDFs only —
+   * supplying one for an image or an Office document returns a 422
+   * (`password_unsupported_content_type`). A wrong password returns a 422
+   * (`encrypted_pdf_wrong_password`); omitting it for a locked PDF returns a 422
+   * (`encrypted_pdf_password_required`). Sent within `options` on the wire.
    */
   password?: string | null;
 }
@@ -85,9 +89,10 @@ export function buildParseForm(params: V2ParseJobCreateParams): Record<string, u
       body[key] = value;
     }
   }
-  // The parse request carries `password` inside `options` (encrypted PDFs are
-  // unsupported — any value returns 422). Fold the top-level convenience param
-  // into the options object, mirroring how `buildExtractBody` folds `strict`.
+  // The parse request carries `password` inside `options` — that is where the
+  // contract puts the key that unlocks an encrypted PDF. Fold the top-level
+  // convenience param into the options object, mirroring how `buildExtractBody`
+  // folds `strict`.
   let opts = options;
   if (password !== undefined && password !== null) {
     if (opts === undefined || opts === null) {

--- a/tests/api-resources/v2/v2.test.ts
+++ b/tests/api-resources/v2/v2.test.ts
@@ -413,6 +413,63 @@ describe('client.v2 routing', () => {
     expect(form.get('password')).toBeNull(); // no longer sent as a top-level field
   });
 
+  test('parse sends the password as the sole option when no other options are given', async () => {
+    let sentBody: unknown;
+    const fetch: Fetch = async (input, init) => {
+      if (!String(input).startsWith('data:')) sentBody = init?.body;
+      return jsonResponse({ markdown: 'x', metadata: {} });
+    };
+    const client = new LandingAIADE({ apikey: 'k', environment: 'staging', maxRetries: 0, fetch });
+    await client.v2.parse({
+      document: await toFile(Buffer.from('%PDF'), 'locked.pdf'),
+      password: 'hunter2',
+    });
+    const form = sentBody as FormData;
+    // Wired by the V2 spec-sync: `options.password` unlocks an encrypted PDF
+    // (it used to be documented as unsupported, always returning a 422), so the
+    // convenience param has to reach the wire even when the caller passes no
+    // other options — the form carries an `options` object it did not ask for.
+    expect(JSON.parse(String(form.get('options')))).toEqual({ password: 'hunter2' });
+  });
+
+  test('parse merges the password into a pre-serialized options string', async () => {
+    let sentBody: unknown;
+    const fetch: Fetch = async (input, init) => {
+      if (!String(input).startsWith('data:')) sentBody = init?.body;
+      return jsonResponse({ markdown: 'x', metadata: {} });
+    };
+    const client = new LandingAIADE({ apikey: 'k', environment: 'staging', maxRetries: 0, fetch });
+    await client.v2.parse({
+      document: await toFile(Buffer.from('%PDF'), 'locked.pdf'),
+      options: '{"pages":[0,1]}', // already JSON-encoded by the caller
+      password: 'hunter2',
+    });
+    const form = sentBody as FormData;
+    expect(JSON.parse(String(form.get('options')))).toEqual({ pages: [0, 1], password: 'hunter2' });
+    expect(form.get('password')).toBeNull();
+  });
+
+  test('parseJobs.create folds the password convenience param into options', async () => {
+    let sentBody: unknown;
+    const fetch: Fetch = async (input, init) => {
+      if (!String(input).startsWith('data:')) sentBody = init?.body;
+      return jsonResponse({ job_id: 'pj-11' }, 202);
+    };
+    const client = new LandingAIADE({ apikey: 'k', environment: 'staging', maxRetries: 0, fetch });
+    // The async route takes the same `ParseOptions` as the sync one, so an
+    // encrypted PDF is unlockable on a job too.
+    const job = await client.v2.parseJobs.create({
+      document: await toFile(Buffer.from('%PDF'), 'locked.pdf'),
+      password: 'hunter2',
+      service_tier: 'priority',
+    });
+    expect(job.job_id).toBe('pj-11');
+    const form = sentBody as FormData;
+    expect(JSON.parse(String(form.get('options')))).toEqual({ password: 'hunter2' });
+    expect(form.get('service_tier')).toBe('priority');
+    expect(form.get('password')).toBeNull();
+  });
+
   test('parseJobs.get normalizes the new result/error/completed_at envelope', async () => {
     const { client } = stubClient(() =>
       jsonResponse({

--- a/tests/contract/v2-smoke.test.ts
+++ b/tests/contract/v2-smoke.test.ts
@@ -298,6 +298,49 @@ describe('V2 contract (staging)', () => {
   );
 
   runIf(
+    'parse (sync) accepts an options password instead of rejecting it outright',
+    async () => {
+      const client = stagingClient();
+      // Wired by the V2 spec-sync: `options.password` used to be documented as
+      // unsupported — ANY value returned a 422 and the advice was to decrypt the
+      // file first. It now unlocks an encrypted PDF, so the field has to survive
+      // the trip: the SDK folds the top-level convenience param into `options`
+      // (see buildParseForm), and the gateway has to take it there.
+      //
+      // The sample is not encrypted, and the spec does not say what a password on
+      // an unencrypted PDF does, so this asserts the pair of outcomes the contract
+      // does cover rather than pinning one: either the parse succeeds, or it fails
+      // with a 422 carrying one of the documented password codes. What it rules out
+      // is the field being rejected as unknown, or a blanket "not supported" 422
+      // under some other code. Does NOT pin `model`, for the same reason as the
+      // tests above — which families a staging cluster can serve depends on how it
+      // was booked, not on the SDK. The wire placement is pinned in the mocked test
+      // in tests/api-resources/v2/v2.test.ts, which controls the request body.
+      const documentedCodes = [
+        'password_unsupported_content_type',
+        'encrypted_pdf_wrong_password',
+        'encrypted_pdf_password_required',
+      ];
+      try {
+        const res = await client.v2.parse({
+          document: await toFile(fs.readFileSync(SAMPLE_PDF), 'sample.pdf', { type: 'application/pdf' }),
+          password: 'not-the-password',
+        });
+        // `metadata` is the only required field on the response; `markdown` and
+        // `structure` are optional, so hold the accepted case to the same bar the
+        // parse tests above use for this sample — a tree with at least one page.
+        expect(res.metadata).toBeDefined();
+        expect((res.structure?.children ?? []).length).toBeGreaterThan(0);
+      } catch (err) {
+        if (!(err instanceof LandingAIADE.UnprocessableEntityError)) throw err;
+        const code = (err.error as { code?: string } | undefined)?.code;
+        expect(documentedCodes).toContain(code);
+      }
+    },
+    120_000, // sync call: 2 x REQUEST_TIMEOUT
+  );
+
+  runIf(
     'parseJobs.list returns a normalized JobList against the new envelope',
     async () => {
       const client = stagingClient();


### PR DESCRIPTION
Automated V2 spec-sync PR (`client.v2`).

- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference types.
- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff. The shipped-but-hand-maintained `/v2/workflow*` surface is not auto-wired, so workflow-only drift lands as a **mechanical-only PR** for a maintainer to reconcile by hand.

Gates (surface-lock, V2 contract tests, lint/build/test) must pass. The V2 ergonomic layer (unified Job, dual-host, schema coercion) is not in the spec, so when present the AI commit is a **draft a human finishes**. **Human review required before merge.**

<!-- what-changed:start -->
## What changed
_AI-generated from the PR diff — verify against the actual changes._

This PR adds a `/v1/ade/classify` endpoint and encrypted-PDF password support for parse, while regenerating the spec snapshot for other unrelated v1/v2 routes.

**Changes:**
- Adds documented support for parsing password-protected PDFs via a top-level `password` param on `client.v2.parse` and `client.v2.parseJobs.create`, folded into the wire's `options` object.
- Documents new 422 error codes for encrypted-PDF handling: `password_unsupported_content_type`, `encrypted_pdf_wrong_password`, and `encrypted_pdf_password_required`.
- Updates the `V2ParseParams.password` doc comment to reflect that encrypted PDFs are now supported (previously documented as unsupported/always erroring).
- Spec snapshot updated with a new `/v1/ade/classify` (sync), `/v1/ade/classify/jobs`, and `/v1/ade/classify/jobs/{job_id}` surface, plus new `ClassifyClass`, `V1ClassifyMetadata`, `Split`, `SplitMetadata`, and `SplitResponse` schema components; no `/v2/workflow*` client surface changes in this PR.
<!-- what-changed:end -->