### PR TITLE
spec-sync(v2): rename job list page_size to pagesize, add cancelled status

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,14 +292,14 @@ try {
 }
 ```
 
-The `create`, `get`, and `wait` methods return a normalized `Job` with `job_id`, `status` (`pending`, `processing`, `completed`, `failed`, or `cancelled`), `progress`, `result`, `metadata`, `error`, `is_terminal`, and `raw` (the unmodified API envelope, for any field not surfaced on the typed shape). `progress` is an estimate, not a measurement: it approaches but never reaches 1 (long-running jobs plateau near 0.98), so key completion off `status`, which can go terminal from any progress value. The `list` method returns a `JobList` with a `jobs` array and `has_more`, plus the `page`/`page_size` pagination fields; `org_id` is populated only by older parse envelopes. Fields an endpoint doesn't populate are `null`.
+The `create`, `get`, and `wait` methods return a normalized `Job` with `job_id`, `status` (`pending`, `processing`, `completed`, `failed`, or `cancelled`), `progress`, `result`, `metadata`, `error`, `is_terminal`, and `raw` (the unmodified API envelope, for any field not surfaced on the typed shape). `progress` is an estimate, not a measurement: it approaches but never reaches 1 (long-running jobs plateau near 0.98), so key completion off `status`, which can go terminal from any progress value. The `list` method takes `page`, `pageSize` (1–100, default 10) and `status`, and returns a `JobList` with a `jobs` array and `has_more`, plus the `page`/`page_size` pagination fields; `org_id` is populated only by older parse envelopes. Fields an endpoint doesn't populate are `null`. The page-size _request_ parameter is `pageSize`; the earlier `page_size` spelling is still accepted and forwarded under the new name, so existing calls keep paginating, but prefer `pageSize`. (The _response_ envelope still reports `page_size`.) A job listed by `client.v2.extractJobs.list` can report `cancelled` as well as `pending`, `processing`, `completed` and `failed`.
 
 ```ts
 // Poll manually instead of blocking
 const current = await client.v2.parseJobs.get(job.job_id);
 
 // List jobs, with optional filtering
-const jobs = await client.v2.parseJobs.list({ status: 'completed', page: 0, page_size: 10 });
+const jobs = await client.v2.parseJobs.list({ status: 'completed', page: 0, pageSize: 10 });
 for (const j of jobs.jobs) {
   console.log(j.job_id, j.status);
 }

--- a/api.md
+++ b/api.md
@@ -63,6 +63,8 @@ A <a href="./src/resources/v2/types.ts">`V2GroundingBox`</a> coordinate arrives 
 
 `client.v2.parse` and `client.v2.parseJobs.create` accept an optional `password` for an encrypted PDF (sent inside `options` on the wire); the document is decrypted at the start of processing and the password is not retained with the result. It is for PDFs only — a password sent with an image or an Office document is a `422` (`password_unsupported_content_type`), as are a wrong password (`encrypted_pdf_wrong_password`) and a locked PDF submitted without one (`encrypted_pdf_password_required`).
 
+The `list` methods on `client.v2.parseJobs` and `client.v2.extractJobs` take `page`, `pageSize` (1–100, default 10) and `status`. `pageSize` is the current name of the page-size query parameter — the earlier `page_size` is still accepted and forwarded under the new name, so existing calls keep paginating, but prefer `pageSize`. A job in a `client.v2.extractJobs.list` page can report `cancelled` in addition to `pending`, `processing`, `completed` and `failed`.
+
 `client.v2.parseJobs` and `client.v2.extractJobs` both return a single, unified <a href="./src/resources/v2/types.ts">`Job`</a> shape even though the underlying parse/extract job envelopes differ upstream — `Job.raw` retains the full original envelope as an escape hatch. `Job.metadata` carries the envelope's top-level metadata receipt (a <a href="./src/resources/v2/types.ts">`V2ParseMetadata`</a> for parse jobs), returned alongside `raw.output_url` when a job created with `output_save_url` completes; it is `null` for inline jobs, whose metadata lives on `Job.result`.
 
 Types:

--- a/specs/_generated/v2-aide.d.ts
+++ b/specs/_generated/v2-aide.d.ts
@@ -1600,7 +1600,7 @@ export interface operations {
                 /** @description Page number (0-indexed). */
                 page?: number;
                 /** @description Number of items per page. */
-                page_size?: number;
+                pageSize?: number;
                 /** @description Filter by job status. */
                 status?: string | null;
             };
@@ -1626,7 +1626,7 @@ export interface operations {
                             job_id?: string;
                             model_version?: string | null;
                             /** @enum {string} */
-                            status?: "pending" | "processing" | "completed" | "failed";
+                            status?: "pending" | "processing" | "completed" | "failed" | "cancelled";
                         }[];
                         page?: number;
                         page_size?: number;
@@ -1923,7 +1923,7 @@ export interface operations {
                 /** @description Page number (0-indexed). */
                 page?: number;
                 /** @description Number of items per page. */
-                page_size?: number;
+                pageSize?: number;
                 /** @description Filter by job status. */
                 status?: string | null;
             };
@@ -1949,7 +1949,7 @@ export interface operations {
                             job_id?: string;
                             model_version?: string | null;
                             /** @enum {string} */
-                            status?: "pending" | "processing" | "completed" | "failed";
+                            status?: "pending" | "processing" | "completed" | "failed" | "cancelled";
                         }[];
                         page?: number;
                         page_size?: number;
@@ -2378,7 +2378,7 @@ export interface operations {
                 /** @description Page number (0-indexed). */
                 page?: number;
                 /** @description Number of items per page. */
-                page_size?: number;
+                pageSize?: number;
                 /** @description Filter by job status. */
                 status?: string | null;
             };
@@ -2404,7 +2404,7 @@ export interface operations {
                             job_id?: string;
                             model_version?: string | null;
                             /** @enum {string} */
-                            status?: "pending" | "processing" | "completed" | "failed";
+                            status?: "pending" | "processing" | "completed" | "failed" | "cancelled";
                         }[];
                         page?: number;
                         page_size?: number;
@@ -2852,7 +2852,7 @@ export interface operations {
                 /** @description Page number (0-indexed). */
                 page?: number;
                 /** @description Number of items per page. */
-                page_size?: number;
+                pageSize?: number;
                 /** @description Filter by job status. */
                 status?: string | null;
             };
@@ -2878,7 +2878,7 @@ export interface operations {
                             job_id?: string;
                             model_version?: string | null;
                             /** @enum {string} */
-                            status?: "pending" | "processing" | "completed" | "failed";
+                            status?: "pending" | "processing" | "completed" | "failed" | "cancelled";
                         }[];
                         page?: number;
                         page_size?: number;
@@ -3175,7 +3175,7 @@ export interface operations {
                 /** @description Page number (0-indexed). */
                 page?: number;
                 /** @description Number of items per page. */
-                page_size?: number;
+                pageSize?: number;
                 /** @description Filter by job status. */
                 status?: string | null;
             };
@@ -3201,7 +3201,7 @@ export interface operations {
                             job_id?: string;
                             model_version?: string | null;
                             /** @enum {string} */
-                            status?: "pending" | "processing" | "completed" | "failed";
+                            status?: "pending" | "processing" | "completed" | "failed" | "cancelled";
                         }[];
                         page?: number;
                         page_size?: number;
@@ -3588,7 +3588,7 @@ export interface operations {
                 /** @description Page number (0-indexed). */
                 page?: number;
                 /** @description Number of items per page. */
-                page_size?: number;
+                pageSize?: number;
                 /** @description Filter by job status. */
                 status?: string | null;
             };
@@ -3614,7 +3614,7 @@ export interface operations {
                             job_id?: string;
                             model_version?: string | null;
                             /** @enum {string} */
-                            status?: "pending" | "processing" | "completed" | "failed";
+                            status?: "pending" | "processing" | "completed" | "failed" | "cancelled";
                         }[];
                         page?: number;
                         page_size?: number;
@@ -4075,7 +4075,7 @@ export interface operations {
                 /** @description Page number (0-indexed). */
                 page?: number;
                 /** @description Number of items per page. */
-                page_size?: number;
+                pageSize?: number;
                 /** @description Filter by job status. */
                 status?: string | null;
             };
@@ -4425,7 +4425,7 @@ export interface operations {
                 /** @description Page number (0-indexed). */
                 page?: number;
                 /** @description Number of items per page. */
-                page_size?: number;
+                pageSize?: number;
                 /** @description Filter by job status. */
                 status?: string | null;
             };
@@ -4451,7 +4451,7 @@ export interface operations {
                             job_id?: string;
                             model_version?: string | null;
                             /** @enum {string} */
-                            status?: "pending" | "processing" | "completed" | "failed";
+                            status?: "pending" | "processing" | "completed" | "failed" | "cancelled";
                         }[];
                         page?: number;
                         page_size?: number;

--- a/specs/v2-aide.json
+++ b/specs/v2-aide.json
@@ -1676,14 +1676,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -1751,7 +1751,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -2329,14 +2330,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -2404,7 +2405,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -3214,14 +3216,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -3289,7 +3291,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -4151,14 +4154,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -4226,7 +4229,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -4844,14 +4848,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -4919,7 +4923,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -5674,14 +5679,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -5749,7 +5754,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -6524,14 +6530,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -7130,14 +7136,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -7205,7 +7211,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }

--- a/src/resources/v2/extract.ts
+++ b/src/resources/v2/extract.ts
@@ -2,16 +2,9 @@ import { LandingAIADEError } from '../../core/error';
 import { RequestOptions } from '../../internal/request-options';
 import { path } from '../../internal/utils/path';
 import { ExtractSchema, coerceSchema } from '../../lib/schema';
-import {
-  V2Resource,
-  WaitOptions,
-  buildJobList,
-  cleanQuery,
-  jobsFromEnvelope,
-  pollUntilTerminal,
-} from './_base';
+import { V2Resource, WaitOptions, buildJobList, jobsFromEnvelope, pollUntilTerminal } from './_base';
 import { normalizeExtractJob } from './_normalize';
-import { V2JobListParams } from './parse';
+import { V2JobListParams, buildJobListQuery } from './parse';
 import { Job, JobList } from './types';
 
 export interface V2ExtractParams {
@@ -110,10 +103,13 @@ export class ExtractJobs extends V2Resource {
     return normalizeExtractJob(raw);
   }
 
-  /** List async extract jobs associated with your API key, newest first. */
+  /**
+   * List async extract jobs associated with your API key, newest first. A
+   * listed job can report `cancelled` alongside the other terminal statuses.
+   */
   async list(query: V2JobListParams = {}, options?: RequestOptions): Promise<JobList> {
     const raw = await this._client.get<Record<string, unknown>>(this.v2Url('/v2/extract/jobs'), {
-      query: cleanQuery(query as Record<string, unknown>),
+      query: buildJobListQuery(query),
       ...options,
     });
     const jobs = jobsFromEnvelope(raw).map(normalizeExtractJob);

--- a/src/resources/v2/parse.ts
+++ b/src/resources/v2/parse.ts
@@ -71,11 +71,40 @@ export interface V2ParseJobCreateParams extends V2ParseParams {
 }
 
 export interface V2JobListParams {
+  /** Page number (0-indexed). Omitted → the server default (`0`). */
   page?: number;
 
+  /**
+   * Number of items per page, 1–100. Omitted → the server default (`10`). Sent
+   * as the `pageSize` query parameter, which is the name the gateway reads.
+   */
+  pageSize?: number;
+
+  /**
+   * @deprecated The gateway renamed this query parameter to `pageSize`. Still
+   * accepted here and forwarded under the new name, so existing callers keep
+   * working; prefer `pageSize`, which wins when both are supplied.
+   */
   page_size?: number;
 
+  /** Filter by job status, e.g. `completed`. Omitted → no filtering. */
   status?: string | null;
+}
+
+/**
+ * Build the query for a `/v2/parse/jobs` or `/v2/extract/jobs` listing. The
+ * gateway renamed the page-size query parameter from `page_size` to `pageSize`,
+ * so `pageSize` is what goes on the wire; the deprecated `page_size` param is
+ * forwarded under the new name rather than sent as-is (the gateway would ignore
+ * it and silently fall back to its default page size).
+ */
+export function buildJobListQuery(query: V2JobListParams): Record<string, unknown> {
+  const { pageSize, page_size, ...rest } = query;
+  const wire: Record<string, unknown> = { ...rest };
+  // `??`, not `||`, so an explicit `0` is preserved; it also treats an omitted
+  // `pageSize` and an explicit `null` alike before falling back to the old name.
+  wire['pageSize'] = pageSize ?? page_size;
+  return cleanQuery(wire);
 }
 
 /**
@@ -148,7 +177,7 @@ export class ParseJobs extends V2Resource {
   /** List async parse jobs associated with your API key, newest first. */
   async list(query: V2JobListParams = {}, options?: RequestOptions): Promise<JobList> {
     const raw = await this._client.get<Record<string, unknown>>(this.v2Url('/v2/parse/jobs'), {
-      query: cleanQuery(query as Record<string, unknown>),
+      query: buildJobListQuery(query),
       ...options,
     });
     const jobs = jobsFromEnvelope(raw).map(normalizeParseJob);

--- a/src/resources/v2/types.ts
+++ b/src/resources/v2/types.ts
@@ -7,9 +7,10 @@
 // original envelope is always available on `Job.raw`.
 
 /**
- * Common job status across parse, extract, and workflow jobs. Extract and
- * workflow jobs never report `cancelled`, but the union is shared so callers
- * only learn one enum.
+ * Common job status across parse, extract, and workflow jobs. Not every route
+ * reports every value — the parse job listing documents only `pending`,
+ * `processing`, `completed` and `failed`, while the extract job listing also
+ * reports `cancelled` — but the union is shared so callers only learn one enum.
  */
 export type JobStatus = 'pending' | 'processing' | 'completed' | 'failed' | 'cancelled';
 

--- a/tests/api-resources/v2/v2.test.ts
+++ b/tests/api-resources/v2/v2.test.ts
@@ -575,6 +575,63 @@ describe('client.v2 routing', () => {
     expect(list.org_id).toBe('o');
   });
 
+  // Wired by the V2 spec-sync: the page-size query parameter on
+  // `/v2/parse/jobs` and `/v2/extract/jobs` was renamed `page_size` -> `pageSize`.
+  test('parseJobs.list sends the page size as the renamed pageSize query param', async () => {
+    const { client, calls } = stubClient(() => jsonResponse({ jobs: [] }));
+    await client.v2.parseJobs.list({ page: 2, pageSize: 25, status: 'completed' });
+    const url = new URL(calls[0]!);
+    expect(url.pathname).toBe('/v2/parse/jobs');
+    expect(url.searchParams.get('pageSize')).toBe('25');
+    expect(url.searchParams.get('page')).toBe('2');
+    expect(url.searchParams.get('status')).toBe('completed');
+    // The old name must not go on the wire — the gateway no longer reads it.
+    expect(url.searchParams.has('page_size')).toBe(false);
+  });
+
+  test('extractJobs.list forwards the deprecated page_size under the new name', async () => {
+    const { client, calls } = stubClient(() => jsonResponse({ jobs: [] }));
+    await client.v2.extractJobs.list({ page_size: 5 });
+    const url = new URL(calls[0]!);
+    expect(url.pathname).toBe('/v2/extract/jobs');
+    expect(url.searchParams.get('pageSize')).toBe('5');
+    expect(url.searchParams.has('page_size')).toBe(false);
+  });
+
+  test('list sends pageSize when both spellings are supplied, and neither when neither is', async () => {
+    const { client, calls } = stubClient(() => jsonResponse({ jobs: [] }));
+    await client.v2.extractJobs.list({ pageSize: 7, page_size: 5 });
+    expect(new URL(calls[0]!).searchParams.get('pageSize')).toBe('7');
+
+    await client.v2.extractJobs.list({ page: 1 });
+    const url = new URL(calls[1]!);
+    expect(url.searchParams.has('pageSize')).toBe(false);
+    expect(url.searchParams.get('page')).toBe('1');
+  });
+
+  // Wired by the V2 spec-sync: the `/v2/extract/jobs` listing now reports
+  // `cancelled` alongside the other statuses.
+  test('extractJobs.list normalizes a cancelled job from the listing', async () => {
+    const { client } = stubClient(() =>
+      jsonResponse({
+        jobs: [
+          { job_id: 'ej-c', status: 'cancelled', created_at: '2026-01-02T03:04:05Z' },
+          { job_id: 'ej-p', status: 'processing' },
+        ],
+        has_more: false,
+        page: 0,
+        page_size: 2,
+      }),
+    );
+    const list = await client.v2.extractJobs.list({ pageSize: 2 });
+    expect(list.jobs[0]!.status).toBe('cancelled');
+    expect(list.jobs[0]!.is_terminal).toBe(true);
+    expect(list.jobs[0]!.result).toBeNull();
+    expect(list.jobs[1]!.status).toBe('processing');
+    expect(list.jobs[1]!.is_terminal).toBe(false);
+    expect(list.page_size).toBe(2);
+  });
+
   test('extractJobs.create sends service_tier in the JSON body', async () => {
     let sentBody: unknown;
     const fetch: Fetch = async (_input, init) => {

--- a/tests/contract/v2-smoke.test.ts
+++ b/tests/contract/v2-smoke.test.ts
@@ -330,12 +330,48 @@ describe('V2 contract (staging)', () => {
     'parseJobs.list returns a normalized JobList against the new envelope',
     async () => {
       const client = stagingClient();
-      const list = await client.v2.parseJobs.list({ page: 0, page_size: 1 });
+      // Wired by the V2 spec-sync: the page-size query parameter was renamed
+      // `page_size` -> `pageSize`, so this passes the new name.
+      const list = await client.v2.parseJobs.list({ page: 0, pageSize: 1 });
       expect(Array.isArray(list.jobs)).toBe(true);
+      // The renamed parameter is honoured: staging may hold fewer than 1 job
+      // under this key, so the bound is one-sided (the old name would be
+      // ignored and fall back to the server default of 10).
+      expect(list.jobs.length).toBeLessThanOrEqual(1);
       for (const job of list.jobs) {
         expect(typeof job.job_id).toBe('string');
         // The list envelope now emits ISO-8601 timestamps; the normalizer maps
         // them to `Date` (or `null` when absent).
+        expect(job.created_at === null || job.created_at instanceof Date).toBe(true);
+      }
+    },
+    60_000, // list route: 1 x REQUEST_TIMEOUT
+  );
+
+  runIf(
+    'extractJobs.list honours the renamed pageSize param and the widened status enum',
+    async () => {
+      const client = stagingClient();
+      // Wired by the V2 spec-sync: `/v2/extract/jobs` renamed its page-size
+      // query parameter `page_size` -> `pageSize` and widened the listed
+      // `status` enum with `cancelled`. Both are asserted absent-or-valid,
+      // which is all a live listing can guarantee: this key may hold no extract
+      // jobs at all, and nothing here can force one into any given state. The
+      // populated `cancelled` case is pinned in the mocked test in
+      // tests/api-resources/v2/v2.test.ts, which controls the response body.
+      const list = await client.v2.extractJobs.list({ page: 0, pageSize: 2 });
+      expect(Array.isArray(list.jobs)).toBe(true);
+      expect(list.jobs.length).toBeLessThanOrEqual(2);
+      // `page`/`page_size` are optional on the listing envelope, so the
+      // normalizer reports `null` when the gateway omits them.
+      expect(list.page == null || typeof list.page === 'number').toBe(true);
+      expect(list.page_size == null || typeof list.page_size === 'number').toBe(true);
+      for (const job of list.jobs) {
+        expect(typeof job.job_id).toBe('string');
+        expect(['pending', 'processing', 'completed', 'failed', 'cancelled']).toContain(job.status);
+        expect(job.is_terminal).toBe(
+          job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled',
+        );
         expect(job.created_at === null || job.created_at instanceof Date).toBe(true);
       }
     },


### PR DESCRIPTION
Automated V2 spec-sync PR (`client.v2`).

- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference types.
- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff. The shipped-but-hand-maintained `/v2/workflow*` surface is not auto-wired, so workflow-only drift lands as a **mechanical-only PR** for a maintainer to reconcile by hand.

Gates (surface-lock, V2 contract tests, lint/build/test) must pass. The V2 ergonomic layer (unified Job, dual-host, schema coercion) is not in the spec, so when present the AI commit is a **draft a human finishes**. **Human review required before merge.**

<!-- what-changed:start -->
## What changed
_AI-generated from the PR diff — verify against the actual changes._

This PR renames the job-listing page-size query parameter to `pageSize` (while still accepting the old `page_size`) and documents that extract job listings can report a `cancelled` status.

**Changes:**
- `client.v2.parseJobs.list` and `client.v2.extractJobs.list` now send `pageSize` as the page-size query parameter, with the deprecated `page_size` still accepted and forwarded under the new name.
- Extract job listings (`client.v2.extractJobs.list`) can now report `cancelled` in addition to the existing terminal statuses.
- `JobStatus` documentation updated to clarify that not every job-listing route reports every status value.
- README and api.md updated to describe the new `pageSize` parameter and the `cancelled` status for extract jobs.
<!-- what-changed:end -->