### PR TITLE
spec-sync(v1): add unsupportedmediatypeerror for 415 responses

### DIFF
--- a/.github/workflows/spec-sync.yml
+++ b/.github/workflows/spec-sync.yml
@@ -943,7 +943,7 @@ jobs:
         if: steps.drift.outputs.code == '10' && steps.existing.outputs.open != 'true'
         env:
           LINT_FIRST: ${{ steps.ai_lint.outcome }}
-          LINT_FINAL: ${{ steps.ai_lint_final.outcome }}   # 'skipped' when the first lint passed
+          LINT_FINAL: ${{ steps.ai_lint_final.outcome }} # 'skipped' when the first lint passed
         run: |
           if [ "$LINT_FIRST" = 'success' ]; then
             lint_note='Lint clean.'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ Every spec-sync PR (and any PR to `main`) must pass `.github/workflows/pr-gates.
   scope, a missing one as not in the spec (in `ade-python#153` the AI pass rewrote the gateway's new
   `/v1/classify` and `/v1/split` routes as `client.v2.classify`/`split` hitting non-existent `/v2/*`
   paths). Reverse: every `/v2/*` spec route outside the hand-maintained `/v2/workflow*` namespace
-  must be *sent* at a `v2Url(...)` call site — a doc-comment mention does not count; the wired
+  must be _sent_ at a `v2Url(...)` call site — a doc-comment mention does not count; the wired
   workflow paths are still validated forward.
 
 Spec-sync PRs are AI-drafted and **require human review** before merge. Every AI step pins

--- a/README.md
+++ b/README.md
@@ -414,16 +414,17 @@ try {
 }
 ```
 
-| Status Code | Error Type                 |
-| ----------- | -------------------------- |
-| 400         | `BadRequestError`          |
-| 401         | `AuthenticationError`      |
-| 403         | `PermissionDeniedError`    |
-| 404         | `NotFoundError`            |
-| 422         | `UnprocessableEntityError` |
-| 429         | `RateLimitError`           |
-| >=500       | `InternalServerError`      |
-| N/A         | `APIConnectionError`       |
+| Status Code | Error Type                  |
+| ----------- | --------------------------- |
+| 400         | `BadRequestError`           |
+| 401         | `AuthenticationError`       |
+| 403         | `PermissionDeniedError`     |
+| 404         | `NotFoundError`             |
+| 415         | `UnsupportedMediaTypeError` |
+| 422         | `UnprocessableEntityError`  |
+| 429         | `RateLimitError`            |
+| >=500       | `InternalServerError`       |
+| N/A         | `APIConnectionError`        |
 
 ### Retries
 

--- a/etc/landingai-ade.api.md
+++ b/etc/landingai-ade.api.md
@@ -218,6 +218,8 @@ class LandingAIADE {
     static toFile: typeof Uploads.toFile;
     // (undocumented)
     static UnprocessableEntityError: typeof Errors.UnprocessableEntityError;
+    // (undocumented)
+    static UnsupportedMediaTypeError: typeof Errors.UnsupportedMediaTypeError;
     //
     // (undocumented)
     v2: V2;
@@ -272,6 +274,10 @@ export function toFile(value: ToFileInput | PromiseLike<ToFileInput>, name?: str
 
 // @public (undocumented)
 export class UnprocessableEntityError extends APIError<422, Headers> {
+}
+
+// @public
+export class UnsupportedMediaTypeError extends APIError<415, Headers> {
 }
 
 //

--- a/specs/_generated/v1-ade.d.ts
+++ b/specs/_generated/v1-ade.d.ts
@@ -1357,6 +1357,13 @@ export interface operations {
                     "application/json": components["schemas"]["ExtractResponse"];
                 };
             };
+            /** @description The request body was not form-encoded. Send multipart/form-data. */
+            415: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -1470,6 +1477,13 @@ export interface operations {
                      */
                     "application/json": components["schemas"]["JobCreationResponse"];
                 };
+            };
+            /** @description The request body was not form-encoded. Send multipart/form-data. */
+            415: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/specs/v1-ade.json
+++ b/specs/v1-ade.json
@@ -2267,6 +2267,9 @@
             },
             "description": "Extraction completed with success but there was a schema validation error."
           },
+          "415": {
+            "description": "The request body was not form-encoded. Send multipart/form-data."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -2440,6 +2443,9 @@
               }
             },
             "description": "Job queued successfully"
+          },
+          "415": {
+            "description": "The request body was not form-encoded. Send multipart/form-data."
           },
           "422": {
             "content": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1110,6 +1110,7 @@ export class LandingAIADE {
   static AuthenticationError = Errors.AuthenticationError;
   static InternalServerError = Errors.InternalServerError;
   static PermissionDeniedError = Errors.PermissionDeniedError;
+  static UnsupportedMediaTypeError = Errors.UnsupportedMediaTypeError;
   static UnprocessableEntityError = Errors.UnprocessableEntityError;
   static V2SyncTimeoutError = Errors.V2SyncTimeoutError;
   static JobWaitTimeoutError = Errors.JobWaitTimeoutError;

--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -74,6 +74,10 @@ export class APIError<
       return new ConflictError(status, error, message, headers);
     }
 
+    if (status === 415) {
+      return new UnsupportedMediaTypeError(status, error, message, headers);
+    }
+
     if (status === 422) {
       return new UnprocessableEntityError(status, error, message, headers);
     }
@@ -120,6 +124,13 @@ export class PermissionDeniedError extends APIError<403, Headers> {}
 export class NotFoundError extends APIError<404, Headers> {}
 
 export class ConflictError extends APIError<409, Headers> {}
+
+/**
+ * The request body was not form-encoded. The V1 `extract` and `extractJobs.create`
+ * routes take `multipart/form-data`; the SDK already sends that, so a 415 usually
+ * means a custom `content-type` header overrode it.
+ */
+export class UnsupportedMediaTypeError extends APIError<415, Headers> {}
 
 export class UnprocessableEntityError extends APIError<422, Headers> {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export {
   AuthenticationError,
   InternalServerError,
   PermissionDeniedError,
+  UnsupportedMediaTypeError,
   UnprocessableEntityError,
   V2SyncTimeoutError,
   JobWaitTimeoutError,

--- a/tests/api-resources/extract-jobs.test.ts
+++ b/tests/api-resources/extract-jobs.test.ts
@@ -1,9 +1,16 @@
-import LandingAIADE from 'landingai-ade';
+import LandingAIADE, { UnsupportedMediaTypeError } from 'landingai-ade';
+import type { Fetch } from 'landingai-ade/internal/builtin-types';
 
 const client = new LandingAIADE({
   apikey: 'My Apikey',
   baseURL: process.env['TEST_API_BASE_URL'] ?? 'http://127.0.0.1:4010',
 });
+
+/** A client backed by a stub fetch that always replies with `response`. */
+function stubClient(response: () => Response): LandingAIADE {
+  const fetch: Fetch = async () => response();
+  return new LandingAIADE({ apikey: 'k', baseURL: 'http://127.0.0.1:4010', maxRetries: 0, fetch });
+}
 
 describe('resource extractJobs', () => {
   // Mock server tests are disabled
@@ -55,5 +62,18 @@ describe('resource extractJobs', () => {
     const dataAndResponse = await responsePromise.withResponse();
     expect(dataAndResponse.data).toBe(response);
     expect(dataAndResponse.response).toBe(rawResponse);
+  });
+
+  test('create surfaces a 415 as UnsupportedMediaTypeError', async () => {
+    // The spec documents a 415 on this route for a body that is not form-encoded.
+    // The route sends multipart/form-data, so a caller only reaches this by
+    // overriding content-type -- but the status must still map to its own class
+    // rather than falling through to the bare APIError.
+    const stubbed = stubClient(
+      () => new Response(null, { status: 415, statusText: 'Unsupported Media Type' }),
+    );
+    const call = stubbed.extractJobs.create({ schema: '{}' });
+    await expect(call).rejects.toBeInstanceOf(UnsupportedMediaTypeError);
+    await expect(call).rejects.toMatchObject({ status: 415 });
   });
 });

--- a/tests/api-resources/top-level.test.ts
+++ b/tests/api-resources/top-level.test.ts
@@ -1,9 +1,16 @@
-import LandingAIADE, { toFile } from 'landingai-ade';
+import LandingAIADE, { UnsupportedMediaTypeError, toFile } from 'landingai-ade';
+import type { Fetch } from 'landingai-ade/internal/builtin-types';
 
 const client = new LandingAIADE({
   apikey: 'My Apikey',
   baseURL: process.env['TEST_API_BASE_URL'] ?? 'http://127.0.0.1:4010',
 });
+
+/** A client backed by a stub fetch that always replies with `response`. */
+function stubClient(response: () => Response): LandingAIADE {
+  const fetch: Fetch = async () => response();
+  return new LandingAIADE({ apikey: 'k', baseURL: 'http://127.0.0.1:4010', maxRetries: 0, fetch });
+}
 
 describe('top level methods', () => {
   // Mock server tests are disabled
@@ -49,6 +56,19 @@ describe('top level methods', () => {
       model: 'model',
       strict: true,
     });
+  });
+
+  test('extract surfaces a 415 as UnsupportedMediaTypeError', async () => {
+    // The spec documents a 415 on this route for a body that is not form-encoded.
+    // The route sends multipart/form-data, so a caller only reaches this by
+    // overriding content-type -- but the status must still map to its own class
+    // rather than falling through to the bare APIError.
+    const stubbed = stubClient(
+      () => new Response(null, { status: 415, statusText: 'Unsupported Media Type' }),
+    );
+    const call = stubbed.extract({ schema: '{}' });
+    await expect(call).rejects.toBeInstanceOf(UnsupportedMediaTypeError);
+    await expect(call).rejects.toMatchObject({ status: 415 });
   });
 
   // Mock server tests are disabled


### PR DESCRIPTION
Automated spec-sync PR.

- **Commit 1 (mechanical):** normalized spec snapshot + regenerated reference types.
- **Commit 2 (AI):** resources/methods/tests/docs wired from the spec diff (added after this PR opened).

Gates (surface-lock, contract tests, lint/build/test) must pass. **Human review required before merge.**

<!-- what-changed:start -->
## What changed
_AI-generated from the PR diff — verify against the actual changes._

This PR adds a new `UnsupportedMediaTypeError` (HTTP 415) error class thrown for form-encoding errors on the extract and extractJobs.create endpoints.

**Changes:**
- Added `UnsupportedMediaTypeError` class exported from `src/index.ts` and `LandingAIADE.UnsupportedMediaTypeError` static property.
- `APIError.generate` now maps HTTP 415 responses to `UnsupportedMediaTypeError`.
- Documented 415 responses ("body was not form-encoded, send multipart/form-data") for the extract and extractJobs create endpoints in the OpenAPI spec.
- Updated README error-type table to include the new 415 `UnsupportedMediaTypeError` entry.
<!-- what-changed:end -->
<!-- spec-sync-nudged: 20711 -->
