### PR TITLE
spec-sync(v2): rename job listing `page_size` param to `pageSize`, keep legacy alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,14 +307,14 @@ try {
 }
 ```
 
-The `create`, `get`, and `wait` methods return a normalized `Job` with `job_id`, `status` (`pending`, `processing`, `completed`, `failed`, or `cancelled`), `progress`, `result`, `metadata`, `error`, `is_terminal`, and `raw` (the unmodified API envelope, for any field not surfaced on the typed shape). `progress` is an estimate, not a measurement: it approaches but never reaches 1 (long-running jobs plateau near 0.98), so key completion off `status`, which can go terminal from any progress value. The `list` method returns a `JobList` with a `jobs` array and `has_more`, plus the `page`/`page_size` pagination fields; `org_id` is populated only by older parse envelopes. Fields an endpoint doesn't populate are `null`.
+The `create`, `get`, and `wait` methods return a normalized `Job` with `job_id`, `status` (`pending`, `processing`, `completed`, `failed`, or `cancelled`), `progress`, `result`, `metadata`, `error`, `is_terminal`, and `raw` (the unmodified API envelope, for any field not surfaced on the typed shape). `progress` is an estimate, not a measurement: it approaches but never reaches 1 (long-running jobs plateau near 0.98), so key completion off `status`, which can go terminal from any progress value. The `list` method returns a `JobList` with a `jobs` array and `has_more`, plus the `page`/`page_size` pagination fields; `org_id` is populated only by older parse envelopes. Fields an endpoint doesn't populate are `null`. Pagination is requested with `page` and `pageSize` — `pageSize` is the name the API gives the per-page query parameter; the older `page_size` spelling is still accepted and folded onto it, so existing callers keep paginating.
 
 ```ts
 // Poll manually instead of blocking
 const current = await client.v2.parseJobs.get(job.job_id);
 
 // List jobs, with optional filtering
-const jobs = await client.v2.parseJobs.list({ status: 'completed', page: 0, page_size: 10 });
+const jobs = await client.v2.parseJobs.list({ status: 'completed', page: 0, pageSize: 10 });
 for (const j of jobs.jobs) {
   console.log(j.job_id, j.status);
 }

--- a/api.md
+++ b/api.md
@@ -63,6 +63,8 @@ A <a href="./src/resources/v2/types.ts">`V2GroundingBox`</a> coordinate arrives 
 
 `client.v2.parse` and `client.v2.parseJobs.create` accept an optional `password` for an encrypted PDF (sent inside `options` on the wire); the document is decrypted at the start of processing and the password is not retained with the result. It is for PDFs only — a password sent with an image or an Office document is a `422` (`password_unsupported_content_type`), as are a wrong password (`encrypted_pdf_wrong_password`) and a locked PDF submitted without one (`encrypted_pdf_password_required`).
 
+Both job listings paginate with `page` and `pageSize` (<a href="./src/resources/v2/parse.ts">`V2JobListParams`</a>): `pageSize` is the name the API gives the per-page query parameter, and the superseded `page_size` spelling stays accepted and is folded onto it before the request is sent. A listed job's `status` may be any <a href="./src/resources/v2/types.ts">`JobStatus`</a> — the extract listing documents `cancelled` alongside `pending`, `processing`, `completed`, and `failed`.
+
 `client.v2.parseJobs` and `client.v2.extractJobs` both return a single, unified <a href="./src/resources/v2/types.ts">`Job`</a> shape even though the underlying parse/extract job envelopes differ upstream — `Job.raw` retains the full original envelope as an escape hatch. `Job.metadata` carries the envelope's top-level metadata receipt (a <a href="./src/resources/v2/types.ts">`V2ParseMetadata`</a> for parse jobs), returned alongside `raw.output_url` when a job created with `output_save_url` completes; it is `null` for inline jobs, whose metadata lives on `Job.result`.
 
 Types:

--- a/specs/_generated/v2-aide.d.ts
+++ b/specs/_generated/v2-aide.d.ts
@@ -1052,7 +1052,7 @@ export interface components {
             duration_ms: number;
             /**
              * Filename
-             * @description Display name of the split document: the URL path's file name for `markdown_url` inputs, or a generated name for inline and uploaded Markdown.
+             * @description Display name of the split document: the uploaded file's name for `markdown` file uploads (`.md` is appended when the name has no suffix), the URL path's file name for `markdown_url` inputs, or a generated name for inline Markdown.
              */
             filename: string;
             /**
@@ -1600,7 +1600,7 @@ export interface operations {
                 /** @description Page number (0-indexed). */
                 page?: number;
                 /** @description Number of items per page. */
-                page_size?: number;
+                pageSize?: number;
                 /** @description Filter by job status. */
                 status?: string | null;
             };
@@ -1626,7 +1626,7 @@ export interface operations {
                             job_id?: string;
                             model_version?: string | null;
                             /** @enum {string} */
-                            status?: "pending" | "processing" | "completed" | "failed";
+                            status?: "pending" | "processing" | "completed" | "failed" | "cancelled";
                         }[];
                         page?: number;
                         page_size?: number;
@@ -1923,7 +1923,7 @@ export interface operations {
                 /** @description Page number (0-indexed). */
                 page?: number;
                 /** @description Number of items per page. */
-                page_size?: number;
+                pageSize?: number;
                 /** @description Filter by job status. */
                 status?: string | null;
             };
@@ -1949,7 +1949,7 @@ export interface operations {
                             job_id?: string;
                             model_version?: string | null;
                             /** @enum {string} */
-                            status?: "pending" | "processing" | "completed" | "failed";
+                            status?: "pending" | "processing" | "completed" | "failed" | "cancelled";
                         }[];
                         page?: number;
                         page_size?: number;
@@ -1993,6 +1993,11 @@ export interface operations {
                      */
                     model?: string | null;
                     /**
+                     * Output Save Url
+                     * @default null
+                     */
+                    output_save_url?: string | null;
+                    /**
                      * Schema
                      * @default null
                      */
@@ -2023,6 +2028,12 @@ export interface operations {
                      * @default null
                      */
                     model?: string | null;
+                    /**
+                     * Output Save Url
+                     * @description JSON-serialized string in form data.
+                     * @default null
+                     */
+                    output_save_url?: string | null;
                     /**
                      * Schema
                      * @description JSON-serialized string in form data.
@@ -2097,9 +2108,13 @@ export interface operations {
                         };
                         /** @description The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued. */
                         job_id?: string;
+                        /** @description The result's metadata block (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Same shape as the inline ``result``'s ``metadata``; inline jobs carry it there instead. */
+                        metadata?: Record<string, never> | null;
+                        /** @description The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``. */
+                        output_url?: string | null;
                         /** @description Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``. */
                         progress?: number;
-                        /** @description Present once status is ``completed``. */
+                        /** @description Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead. */
                         result?: {
                             /** Extraction */
                             extraction?: {
@@ -2378,7 +2393,7 @@ export interface operations {
                 /** @description Page number (0-indexed). */
                 page?: number;
                 /** @description Number of items per page. */
-                page_size?: number;
+                pageSize?: number;
                 /** @description Filter by job status. */
                 status?: string | null;
             };
@@ -2404,7 +2419,7 @@ export interface operations {
                             job_id?: string;
                             model_version?: string | null;
                             /** @enum {string} */
-                            status?: "pending" | "processing" | "completed" | "failed";
+                            status?: "pending" | "processing" | "completed" | "failed" | "cancelled";
                         }[];
                         page?: number;
                         page_size?: number;
@@ -2852,7 +2867,7 @@ export interface operations {
                 /** @description Page number (0-indexed). */
                 page?: number;
                 /** @description Number of items per page. */
-                page_size?: number;
+                pageSize?: number;
                 /** @description Filter by job status. */
                 status?: string | null;
             };
@@ -2878,7 +2893,7 @@ export interface operations {
                             job_id?: string;
                             model_version?: string | null;
                             /** @enum {string} */
-                            status?: "pending" | "processing" | "completed" | "failed";
+                            status?: "pending" | "processing" | "completed" | "failed" | "cancelled";
                         }[];
                         page?: number;
                         page_size?: number;
@@ -3175,7 +3190,7 @@ export interface operations {
                 /** @description Page number (0-indexed). */
                 page?: number;
                 /** @description Number of items per page. */
-                page_size?: number;
+                pageSize?: number;
                 /** @description Filter by job status. */
                 status?: string | null;
             };
@@ -3201,7 +3216,7 @@ export interface operations {
                             job_id?: string;
                             model_version?: string | null;
                             /** @enum {string} */
-                            status?: "pending" | "processing" | "completed" | "failed";
+                            status?: "pending" | "processing" | "completed" | "failed" | "cancelled";
                         }[];
                         page?: number;
                         page_size?: number;
@@ -3588,7 +3603,7 @@ export interface operations {
                 /** @description Page number (0-indexed). */
                 page?: number;
                 /** @description Number of items per page. */
-                page_size?: number;
+                pageSize?: number;
                 /** @description Filter by job status. */
                 status?: string | null;
             };
@@ -3614,7 +3629,7 @@ export interface operations {
                             job_id?: string;
                             model_version?: string | null;
                             /** @enum {string} */
-                            status?: "pending" | "processing" | "completed" | "failed";
+                            status?: "pending" | "processing" | "completed" | "failed" | "cancelled";
                         }[];
                         page?: number;
                         page_size?: number;
@@ -4075,7 +4090,7 @@ export interface operations {
                 /** @description Page number (0-indexed). */
                 page?: number;
                 /** @description Number of items per page. */
-                page_size?: number;
+                pageSize?: number;
                 /** @description Filter by job status. */
                 status?: string | null;
             };
@@ -4425,7 +4440,7 @@ export interface operations {
                 /** @description Page number (0-indexed). */
                 page?: number;
                 /** @description Number of items per page. */
-                page_size?: number;
+                pageSize?: number;
                 /** @description Filter by job status. */
                 status?: string | null;
             };
@@ -4451,7 +4466,7 @@ export interface operations {
                             job_id?: string;
                             model_version?: string | null;
                             /** @enum {string} */
-                            status?: "pending" | "processing" | "completed" | "failed";
+                            status?: "pending" | "processing" | "completed" | "failed" | "cancelled";
                         }[];
                         page?: number;
                         page_size?: number;

--- a/specs/v2-aide.json
+++ b/specs/v2-aide.json
@@ -763,7 +763,7 @@
             "type": "integer"
           },
           "filename": {
-            "description": "Display name of the split document: the URL path's file name for `markdown_url` inputs, or a generated name for inline and uploaded Markdown.",
+            "description": "Display name of the split document: the uploaded file's name for `markdown` file uploads (`.md` is appended when the name has no suffix), the URL path's file name for `markdown_url` inputs, or a generated name for inline Markdown.",
             "title": "Filename",
             "type": "string"
           },
@@ -1676,14 +1676,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -1751,7 +1751,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -2143,7 +2144,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own\nextras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on\nthe R&D ``/api/extract`` contract, so the customer surface publishes the VTRA\ncontract and only that.",
+                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``, ``output_save_url``. AIDE's\nown extras (``return_reasoning``, ``fallback_model``) stay on the R&D\n``/api/extract`` contract — only ``output_save_url`` is shared with it, because\nit is also on VTRA's async wire (aide#2053, the extract half of the\n``output_save_url``/ZDR parity pair that started with parse in #2056's\npredecessor) — so the customer surface publishes the VTRA contract and only\nthat.",
                 "properties": {
                   "markdown": {
                     "anyOf": [
@@ -2329,14 +2330,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -2404,7 +2405,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -2449,7 +2451,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``. Nothing else — AIDE's own\nextras (``return_reasoning``, ``fallback_model``, ``output_save_url``) stay on\nthe R&D ``/api/extract`` contract, so the customer surface publishes the VTRA\ncontract and only that.",
+                "description": "Input to V1ExtractOperationWorkflow — the ``/v1/extract`` request body.\n\nVTRA's ``ExtractRequest`` exactly: ``model``, ``markdown`` (file part OR inline\nstring), ``markdown_url``, ``schema``, ``strict``, ``output_save_url``. AIDE's\nown extras (``return_reasoning``, ``fallback_model``) stay on the R&D\n``/api/extract`` contract — only ``output_save_url`` is shared with it, because\nit is also on VTRA's async wire (aide#2053, the extract half of the\n``output_save_url``/ZDR parity pair that started with parse in #2056's\npredecessor) — so the customer surface publishes the VTRA contract and only\nthat.",
                 "properties": {
                   "markdown": {
                     "anyOf": [
@@ -2486,6 +2488,18 @@
                     ],
                     "default": null,
                     "title": "Model"
+                  },
+                  "output_save_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Output Save Url"
                   },
                   "schema": {
                     "anyOf": [
@@ -2557,6 +2571,19 @@
                     "default": null,
                     "description": "JSON-serialized string in form data.",
                     "title": "Model"
+                  },
+                  "output_save_url": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "JSON-serialized string in form data.",
+                    "title": "Output Save Url"
                   },
                   "schema": {
                     "anyOf": [
@@ -2698,6 +2725,20 @@
                       "description": "The unique identifier for this v1-ade-extract job. Format: ``extract-<26-character Crockford base32 ULID>`` (``[0-9a-hjkmnp-tv-z]{26}`` tail). Opaque, server-minted, and stable for the life of the job — the same id is returned on the sync response, the async 202, and every poll. Treat it as opaque; older id formats remain accepted indefinitely and are never re-issued.",
                       "type": "string"
                     },
+                    "metadata": {
+                      "description": "The result's metadata block (billing included), present alongside ``output_url`` once a job with ``output_save_url`` has ``completed`` — the delivery moves the content, not the receipt. Same shape as the inline ``result``'s ``metadata``; inline jobs carry it there instead.",
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "output_url": {
+                      "description": "The URL the result was delivered to. Present once the job has ``completed`` and ``output_save_url`` was set, instead of inline ``result``.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
                     "progress": {
                       "description": "Estimated completion as a decimal from 0 to 1 — an estimate, not a measurement: it typically advances between polls while the job is ``processing``, may jump forward when the service reports a real milestone (e.g. parsed pages), and approaches but never reaches 1 (long-running jobs plateau near 0.98 — completion is signaled by ``status``, and a job may complete from any progress value). Present while ``processing``.",
                       "maximum": 1,
@@ -2730,7 +2771,7 @@
                           "type": "null"
                         }
                       ],
-                      "description": "Present once status is ``completed``."
+                      "description": "Present once status is ``completed`` and ``output_save_url`` was not set. When ``output_save_url`` was set, the result is delivered there and ``output_url`` is returned instead."
                     },
                     "status": {
                       "enum": [
@@ -3214,14 +3255,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -3289,7 +3330,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -4151,14 +4193,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -4226,7 +4268,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -4844,14 +4887,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -4919,7 +4962,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -5674,14 +5718,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -5749,7 +5793,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }
@@ -6524,14 +6569,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -7130,14 +7175,14 @@
           {
             "description": "Number of items per page.",
             "in": "query",
-            "name": "page_size",
+            "name": "pageSize",
             "required": false,
             "schema": {
               "default": 10,
               "description": "Number of items per page.",
               "maximum": 100,
               "minimum": 1,
-              "title": "Page Size",
+              "title": "Pagesize",
               "type": "integer"
             }
           },
@@ -7205,7 +7250,8 @@
                               "pending",
                               "processing",
                               "completed",
-                              "failed"
+                              "failed",
+                              "cancelled"
                             ],
                             "type": "string"
                           }

--- a/src/resources/v2/extract.ts
+++ b/src/resources/v2/extract.ts
@@ -2,16 +2,9 @@ import { LandingAIADEError } from '../../core/error';
 import { RequestOptions } from '../../internal/request-options';
 import { path } from '../../internal/utils/path';
 import { ExtractSchema, coerceSchema } from '../../lib/schema';
-import {
-  V2Resource,
-  WaitOptions,
-  buildJobList,
-  cleanQuery,
-  jobsFromEnvelope,
-  pollUntilTerminal,
-} from './_base';
+import { V2Resource, WaitOptions, buildJobList, jobsFromEnvelope, pollUntilTerminal } from './_base';
 import { normalizeExtractJob } from './_normalize';
-import { V2JobListParams } from './parse';
+import { V2JobListParams, buildJobListQuery } from './parse';
 import { Job, JobList } from './types';
 
 export interface V2ExtractParams {
@@ -110,10 +103,13 @@ export class ExtractJobs extends V2Resource {
     return normalizeExtractJob(raw);
   }
 
-  /** List async extract jobs associated with your API key, newest first. */
+  /**
+   * List async extract jobs associated with your API key, newest first. A listed
+   * job may report any `JobStatus`, `cancelled` included.
+   */
   async list(query: V2JobListParams = {}, options?: RequestOptions): Promise<JobList> {
     const raw = await this._client.get<Record<string, unknown>>(this.v2Url('/v2/extract/jobs'), {
-      query: cleanQuery(query as Record<string, unknown>),
+      query: buildJobListQuery(query),
       ...options,
     });
     const jobs = jobsFromEnvelope(raw).map(normalizeExtractJob);

--- a/src/resources/v2/parse.ts
+++ b/src/resources/v2/parse.ts
@@ -78,9 +78,43 @@ export interface V2ParseJobCreateParams extends V2ParseParams {
 export interface V2JobListParams {
   page?: number;
 
+  /**
+   * Number of items per page. Sent on the wire as `pageSize`, which is the name
+   * the spec gives this query parameter on `/v2/parse/jobs` and
+   * `/v2/extract/jobs` (the V1 job listings already spelled it that way).
+   */
+  pageSize?: number;
+
+  /**
+   * Superseded spelling of `pageSize`, still accepted so existing callers keep
+   * paginating: on `parseJobs.list` and `extractJobs.list` a value passed here is
+   * folded onto `pageSize` before the request goes out rather than sent under
+   * this name. The spec no longer declares a `page_size` query parameter, and an
+   * undeclared query parameter is dropped by the gateway -- sending it verbatim
+   * would silently fall back to the default page size instead of erroring. An
+   * explicit `pageSize` takes precedence.
+   */
   page_size?: number;
 
   status?: string | null;
+}
+
+/**
+ * Build the query for a V2 job listing: fold the superseded `page_size`
+ * spelling onto the wire name `pageSize` (see `V2JobListParams`) so both reach
+ * the gateway, and drop params left unset.
+ */
+export function buildJobListQuery(query: V2JobListParams): Record<string, unknown> {
+  const { page_size: legacyPageSize, pageSize, ...rest } = query;
+  const out = cleanQuery(rest as Record<string, unknown>);
+  // Test the value, not key presence: `{ pageSize: undefined }` is how JS spells
+  // "absent", so it has to fall through to `page_size` rather than suppress it.
+  // `!= null` covers an absent key and an explicit `null` alike.
+  const perPage = pageSize != null ? pageSize : legacyPageSize;
+  if (perPage != null) {
+    out['pageSize'] = perPage;
+  }
+  return out;
 }
 
 /**
@@ -183,7 +217,7 @@ export class ParseJobs extends V2Resource {
   /** List async parse jobs associated with your API key, newest first. */
   async list(query: V2JobListParams = {}, options?: RequestOptions): Promise<JobList> {
     const raw = await this._client.get<Record<string, unknown>>(this.v2Url('/v2/parse/jobs'), {
-      query: cleanQuery(query as Record<string, unknown>),
+      query: buildJobListQuery(query),
       ...options,
     });
     const jobs = jobsFromEnvelope(raw).map(normalizeParseJob);

--- a/src/resources/v2/types.ts
+++ b/src/resources/v2/types.ts
@@ -7,9 +7,11 @@
 // original envelope is always available on `Job.raw`.
 
 /**
- * Common job status across parse, extract, and workflow jobs. Extract and
- * workflow jobs never report `cancelled`, but the union is shared so callers
- * only learn one enum.
+ * Common job status across parse, extract, and workflow jobs, so callers only
+ * learn one enum. Extract job listings now document `cancelled` alongside the
+ * other four; which values a given endpoint actually emits is the endpoint's
+ * business, so treat any of the five as possible and key terminality off
+ * `Job.is_terminal`.
  */
 export type JobStatus = 'pending' | 'processing' | 'completed' | 'failed' | 'cancelled';
 

--- a/tests/api-resources/v2/v2.test.ts
+++ b/tests/api-resources/v2/v2.test.ts
@@ -730,6 +730,57 @@ describe('client.v2 routing', () => {
     expect(list.org_id).toBe('o');
   });
 
+  test('parseJobs.list sends the per-page count under the spec name pageSize', async () => {
+    const { client, calls } = stubClient(() => jsonResponse({ jobs: [] }));
+    await client.v2.parseJobs.list({ page: 1, pageSize: 5, status: 'completed' });
+    const url = new URL(calls[0]!);
+    expect(url.pathname).toBe('/v2/parse/jobs');
+    expect(url.searchParams.get('pageSize')).toBe('5');
+    expect(url.searchParams.get('page')).toBe('1');
+    expect(url.searchParams.get('status')).toBe('completed');
+    // The spec renamed the parameter, so the old name must not reach the wire —
+    // the gateway drops an undeclared query param instead of erroring on it.
+    expect(url.searchParams.has('page_size')).toBe(false);
+  });
+
+  test('extractJobs.list folds the superseded page_size spelling onto pageSize', async () => {
+    const { client, calls } = stubClient(() => jsonResponse({ jobs: [] }));
+    await client.v2.extractJobs.list({ page_size: 7 });
+    const url = new URL(calls[0]!);
+    expect(url.pathname).toBe('/v2/extract/jobs');
+    expect(url.searchParams.get('pageSize')).toBe('7');
+    expect(url.searchParams.has('page_size')).toBe(false);
+  });
+
+  test('an explicit pageSize wins over the superseded page_size', async () => {
+    const { client, calls } = stubClient(() => jsonResponse({ jobs: [] }));
+    // `page_size` is only a fallback: an `undefined` `pageSize` is how JS spells
+    // "absent", so the value is what decides, not key presence.
+    await client.v2.parseJobs.list({ pageSize: 3, page_size: 9 });
+    expect(new URL(calls[0]!).searchParams.getAll('pageSize')).toEqual(['3']);
+  });
+
+  test('extractJobs.list normalizes a cancelled job as terminal', async () => {
+    const { client } = stubClient(() =>
+      jsonResponse({
+        jobs: [
+          { job_id: 'ej-c', status: 'cancelled', created_at: '2026-01-02T03:04:05Z' },
+          { job_id: 'ej-p', status: 'processing' },
+        ],
+        has_more: false,
+        page: 0,
+        page_size: 10,
+      }),
+    );
+    // Wired by the V2 spec-sync: the `/v2/extract/jobs` listing now documents
+    // `cancelled` alongside pending/processing/completed/failed.
+    const list = await client.v2.extractJobs.list();
+    expect(list.jobs.map((job) => job.status)).toEqual(['cancelled', 'processing']);
+    expect(list.jobs[0]!.is_terminal).toBe(true);
+    expect(list.jobs[1]!.is_terminal).toBe(false);
+    expect(list.page_size).toBe(10);
+  });
+
   test('extractJobs.create sends service_tier in the JSON body', async () => {
     let sentBody: unknown;
     const fetch: Fetch = async (_input, init) => {

--- a/tests/contract/v2-smoke.test.ts
+++ b/tests/contract/v2-smoke.test.ts
@@ -327,9 +327,43 @@ describe('V2 contract (staging)', () => {
   );
 
   runIf(
+    'extractJobs.list honours the renamed pageSize parameter',
+    async () => {
+      const client = stagingClient();
+      // Wired by the V2 spec-sync: the per-page query parameter on the /v2 job
+      // listings is now named `pageSize` (it was `page_size`), and the extract
+      // listing documents `cancelled` alongside the other four statuses. Asking
+      // for one job per page is a guaranteed answer whatever this key's jobs
+      // look like: the page can be empty, but it cannot exceed the requested
+      // size — if the SDK sent the superseded name the gateway would drop it and
+      // fall back to a page of 10. Nothing here assumes a job exists, and no
+      // status is required to appear; the specific statuses are pinned in the
+      // mocked test in tests/api-resources/v2/v2.test.ts.
+      const list = await client.v2.extractJobs.list({ page: 0, pageSize: 1 });
+      expect(Array.isArray(list.jobs)).toBe(true);
+      expect(list.jobs.length).toBeLessThanOrEqual(1);
+      // `page_size` on the RESPONSE envelope keeps its snake_case name — only the
+      // query parameter was renamed. The envelope may omit it, and nothing pins
+      // which value it echoes, so this is absent-or-a-number only.
+      expect(list.page_size == null || typeof list.page_size === 'number').toBe(true);
+      for (const job of list.jobs) {
+        expect(typeof job.job_id).toBe('string');
+        expect(['pending', 'processing', 'completed', 'failed', 'cancelled']).toContain(job.status);
+        expect(job.is_terminal).toBe(
+          job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled',
+        );
+      }
+    },
+    60_000, // list route: 1 x REQUEST_TIMEOUT
+  );
+
+  runIf(
     'parseJobs.list returns a normalized JobList against the new envelope',
     async () => {
       const client = stagingClient();
+      // Keeps using the superseded `page_size` spelling on purpose: the SDK folds
+      // it onto the wire's `pageSize`, so this also gates that older callers
+      // still paginate against the renamed parameter.
       const list = await client.v2.parseJobs.list({ page: 0, page_size: 1 });
       expect(Array.isArray(list.jobs)).toBe(true);
       for (const job of list.jobs) {


### PR DESCRIPTION
Automated V2 spec-sync PR (`client.v2`).

- **Commit 1 (mechanical):** normalized V2 spec snapshot + regenerated reference types.
- **Commit 2 (AI, only if the spec diff needs SDK changes):** client.v2 resources/methods/tests/docs wired from the diff. The shipped-but-hand-maintained `/v2/workflow*` surface is not auto-wired, so workflow-only drift lands as a **mechanical-only PR** for a maintainer to reconcile by hand.

Gates (surface-lock, V2 contract tests, lint/build/test) must pass. The V2 ergonomic layer (unified Job, dual-host, schema coercion) is not in the spec, so when present the AI commit is a **draft a human finishes**. **Human review required before merge.**

<!-- what-changed:start -->
## What changed
_AI-generated from the PR diff — verify against the actual changes._

This PR renames the job-listing pagination query parameter to `pageSize` while keeping `page_size` accepted as a backward-compatible alias, and adds `output_save_url`/`output_url`/`metadata` support to async extract jobs.

**Changes:**
- `client.v2.parseJobs.list` and `client.v2.extractJobs.list` now send `pageSize` on the wire; the legacy `page_size` param is still accepted and folded onto `pageSize`.
- `client.v2.extract` and `client.v2.extractJobs.create` now accept an `output_save_url` parameter, matching the existing parse behavior.
- Extract job responses (`Job.raw`) now include `output_url` and `metadata` fields when `output_save_url` was used, and `result` is omitted in that case.
- `JobStatus` documentation now notes extract job listings can also report `cancelled`, not just parse jobs.
- The spec snapshot for `/v2/workflow*` routes was updated but no client surface changed in this PR.
<!-- what-changed:end -->